### PR TITLE
evse.cpp, evse.h: read imported and exported energy from mainsmeter+e…

### DIFF
--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -31,7 +31,7 @@
 //the on-screen instructions for verbose/warning/info/... do not apply, 
 //the debug messages that are compiled in are always shown for backwards compatibility reasons
 //uncomment for production release, comment this to debug via wifi:
-//#define DEBUG_DISABLED 1
+#define DEBUG_DISABLED 1
 
 #ifndef VERSION
 #ifdef DEBUG_DISABLED
@@ -48,7 +48,7 @@
 #define LOG_OFF 0
 
 #define LOG_EVSE LOG_INFO                                                       // Default: LOG_INFO
-#define LOG_MODBUS LOG_DEBUG                                                     // Default: LOG_WARN
+#define LOG_MODBUS LOG_WARN                                                     // Default: LOG_WARN
 
 
 #ifdef DEBUG_DISABLED

--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -31,7 +31,7 @@
 //the on-screen instructions for verbose/warning/info/... do not apply, 
 //the debug messages that are compiled in are always shown for backwards compatibility reasons
 //uncomment for production release, comment this to debug via wifi:
-#define DEBUG_DISABLED 1
+//#define DEBUG_DISABLED 1
 
 #ifndef VERSION
 #ifdef DEBUG_DISABLED
@@ -48,7 +48,7 @@
 #define LOG_OFF 0
 
 #define LOG_EVSE LOG_INFO                                                       // Default: LOG_INFO
-#define LOG_MODBUS LOG_WARN                                                     // Default: LOG_WARN
+#define LOG_MODBUS LOG_DEBUG                                                     // Default: LOG_WARN
 
 
 #ifdef DEBUG_DISABLED

--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -502,8 +502,10 @@ struct EMstruct {
     uint8_t IDivisor;       // 10^x
     uint16_t PRegister;     // Total power (W) -- only used for EV/PV meter momentary power
     uint8_t PDivisor;       // 10^x
-    uint16_t ERegister;     // Total energy (kWh)
+    uint16_t ERegister;     // Total imported energy (kWh); equals total energy if meter doesnt support exported energy
     uint8_t EDivisor;       // 10^x
+    uint16_t ERegister_Exp; // Total exported energy (kWh)
+    uint8_t EDivisor_Exp;   // 10^x
 };
 
 extern struct EMstruct EMConfig[EM_CUSTOM + 1];

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -1862,6 +1862,7 @@ uint8_t PollEVNode = NR_EVSES;
                         processAllNodeStates(ModbusRequest - 13u);
                         break;
                     }
+                    ModbusRequest = 21;
                 case 20:                                                         // EV kWh meter, Current measurement
                     // Request Current if EV meter is configured
                     if (EVMeter) {


### PR DESCRIPTION
evse.cpp, evse.h: read imported and exported energy from mainsmeter+evmeter and feed them to the API

For SmartEVSE we have to put our EVmeters (mains, solar panels) on a modbus, so SmartEVSE can read them and adapt the charging current. SmartEVSE is the master of the bus, and only one master is allowed.
A lot of users want to have this information on their domotics systems (like Domoticz, Home Assistant) or other systems, for monitoring, making graphs etc. 

This PR reads the energy information (import and export separated) of the modbus and presents it to the REST API, so other systems can process them.

Has been running stable here for weeks now, so I feel confident putting it out there... 