### PR TITLE
evse.h, OneWire.cpp: introduce FAKE_RFID for debugging without an RFI…

### DIFF
--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -34,6 +34,8 @@
 #define DEBUG_DISABLED 1
 
 //uncomment this to emulate an rfid reader with rfid of card = 123456
+//showing the rfid card is simulated by executing http://smartevse-xxx.lan/debug?showrfid=1
+//don't forget to first store the card before it can activate charging
 //#define FAKE_RFID 1
 
 #ifndef VERSION

--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -33,6 +33,9 @@
 //uncomment for production release, comment this to debug via wifi:
 #define DEBUG_DISABLED 1
 
+//uncomment this to emulate an rfid reader with rfid of card = 123456
+//#define FAKE_RFID 1
+
 #ifndef VERSION
 #ifdef DEBUG_DISABLED
 #define VERSION "v3serkri-0.00"
@@ -386,6 +389,9 @@ extern uint8_t PVMeterAddress;
 extern uint8_t EVMeter;                                                         // Type of EV electric meter (0: Disabled / Constants EM_*)
 extern uint8_t EVMeterAddress;
 extern uint8_t RFIDReader;
+#ifdef FAKE_RFID
+extern uint8_t Show_RFID;
+#endif
 extern uint8_t WIFImode;
 
 extern int32_t Irms[3];                                                         // Momentary current per Phase (Amps *10) (23 = 2.3A)

--- a/SmartEVSE-3/src/OneWire.cpp
+++ b/SmartEVSE-3/src/OneWire.cpp
@@ -112,6 +112,25 @@ unsigned char OneWireRead(void) {
     return r;
 }
 
+#ifdef FAKE_RFID
+unsigned char OneWireReadCardId(void) {
+    if (!RFIDstatus && Show_RFID) { //if ready to accept new card and it is shown
+        RFID[0] = 0x01; //Family Code
+        RFID[1] = 0x01; //RFID id = "01 02 03 04 05 06"
+        RFID[2] = 0x02;
+        RFID[3] = 0x03;
+        RFID[4] = 0x04;
+        RFID[5] = 0x05;
+        RFID[6] = 0x06;
+        RFID[7] = 0xf0; //crc8 code  TODO is this ok?
+        Show_RFID = 0; //this makes "showing" the RFID a one shot event
+        return 1;
+    }
+    else
+        return 0; //card is already read, no new card
+}
+
+#else
 unsigned char OneWireReadCardId(void) {
     unsigned char x;
 
@@ -122,14 +141,14 @@ unsigned char OneWireReadCardId(void) {
             RFID[0] = 0;                                                        // CRC incorrect, clear first byte of RFID buffer
             return 0;
         } else {
-//            for (x=1 ; x<7 ; x++) printf("%02x",RFID[x]);
-//            printf("\r\n");
+            for (x=1 ; x<7 ; x++) _Serialprintf("%02x",RFID[x]);
+            _Serialprintf("\r\n");
             return 1;
         }
     }
     return 0;
 }
-
+#endif
 
 
 // ############################## RFID functions ##############################
@@ -163,7 +182,7 @@ void WriteRFIDlist(void) {
     
 
 #ifdef LOG_DEBUG_EVSE
-    printf("\nRFID list saved\n");
+    _Serialprintf("\nRFID list saved\n");
 #endif
 }
 
@@ -199,12 +218,12 @@ unsigned char StoreRFID(void) {
     } while (r !=0 && offset < 120);
     if (r != 0) return 0;                                                       // no more room to store RFID
     offset -= 6;
-//    printf("offset %u ",offset);
+    _Serialprintf("offset %u ",offset);
     memcpy(RFIDlist + offset, RFID+1, 6);
 
 #ifdef LOG_DEBUG_EVSE
-    printf("\nRFIDlist:");
-    for (r=0; r<120; r++) printf("%02x",RFIDlist[r]);
+    _Serialprintf("\nRFIDlist:");
+    for (r=0; r<120; r++) _Serialprintf("%02x",RFIDlist[r]);
 #endif
 
     WriteRFIDlist();
@@ -222,8 +241,8 @@ unsigned char DeleteRFID(void) {
         for (r = 0; r < 6; r++) RFIDlist[offset + r] = 0xff;
     } else return 0;
 
-//    printf("deleted %u ",offset);
-//    for (r=0; r<120; r++) printf("%02x",RFIDlist[r]);
+    _Serialprintf("deleted %u ",offset);
+    for (r=0; r<120; r++) _Serialprintf("%02x",RFIDlist[r]);
     
     WriteRFIDlist();
     return 1;
@@ -235,7 +254,7 @@ void DeleteAllRFID(void) {
     for (i = 0; i < 120; i++) RFIDlist[i] = 0xff;
     WriteRFIDlist();
 #ifdef LOG_INFO_EVSE
-    printf("All RFID cards erased!\n");
+    _Serialprintf("All RFID cards erased!\n");
 #endif
     RFIDReader = 0;                                                             // RFID Reader Disabled
 }
@@ -243,7 +262,6 @@ void DeleteAllRFID(void) {
 void CheckRFID(void) {
     unsigned char x;
     static unsigned char cardoffset = 0;
-
     // When RFID is enabled, a OneWire RFID reader is expected on the SW input
     if (RFIDReader) {                                                           // RFID Reader set to Enabled, Learn or Delete
         if (OneWireReadCardId() ) {                                             // Read card ID
@@ -251,7 +269,7 @@ void CheckRFID(void) {
                 case 1:                                                         // EnableAll. All learned cards accepted for locking /unlocking
                     x = MatchRFID();
                     if (x && !RFIDstatus) {
-                        //printf("RFID card found!\n");
+                        _Serialprintf("RFID card found!\n");
                         if (Access_bit) {
                             setAccess(false);                                   // Access Off, Switch back to state B1/C1
                         } else Access_bit = 1;
@@ -263,7 +281,7 @@ void CheckRFID(void) {
                 case 2:                                                         // EnableOne. Only the card that unlocks, can re-lock the EVSE   
                     x = MatchRFID();
                     if (x && !RFIDstatus) {
-                        //printf("RFID card found!\n");
+                        _Serialprintf("RFID card found!\n");
                         if (!Access_bit) {
                             cardoffset = x;                                     // store cardoffset from current card
                             Access_bit = 1;                                     // Access On
@@ -277,23 +295,23 @@ void CheckRFID(void) {
                 case 3:                                                         // Learn Card
                     x = StoreRFID();
                     if (x == 1) {
-                        printf("RFID card stored!\n");
+                        _Serialprintf("RFID card stored!\n");
                         RFIDstatus = 2;
                     } else if (x == 2 && !RFIDstatus) {
-                        printf("RFID card was already stored!\n");
+                        _Serialprintf("RFID card was already stored!\n");
                         RFIDstatus = 4;
                     } else if (!RFIDstatus) {
-                        printf("RFID storage full! Delete card first\n");
+                        _Serialprintf("RFID storage full! Delete card first\n");
                         RFIDstatus = 6;
                     }
                     break;
                 case 4:                                                         // Delete Card
                     x = DeleteRFID();
                     if (x) {
-                        printf("RFID card deleted!\n");
+                        _Serialprintf("RFID card deleted!\n");
                         RFIDstatus = 3;
                     } else if (!RFIDstatus) {
-                        printf("RFID card not in list!\n");
+                        _Serialprintf("RFID card not in list!\n");
                         RFIDstatus = 5;
                     }
                     break;

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -97,6 +97,7 @@ uint16_t MaxCircuit = MAX_CIRCUIT;                                          // M
 uint8_t Config = CONFIG;                                                    // Configuration (0:Socket / 1:Fixed Cable)
 uint8_t LoadBl = LOADBL;                                                    // Load Balance Setting (0:Disable / 1:Master / 2-8:Node)
 uint8_t Switch = SWITCH;                                                    // External Switch (0:Disable / 1:Access B / 2:Access S / 3:Smart-Solar B / 4:Smart-Solar S)
+                                                                            // B=momentary push button, S=toggle switch
 uint8_t RCmon = RC_MON;                                                     // Residual Current Monitor (0:Disable / 1:Enable)
 uint16_t StartCurrent = START_CURRENT;
 uint16_t StopTime = STOP_TIME;
@@ -110,6 +111,9 @@ uint8_t Grid = GRID;                                                        // T
 uint8_t EVMeter = EV_METER;                                                 // Type of EV electric meter (0: Disabled / Constants EM_*)
 uint8_t EVMeterAddress = EV_METER_ADDRESS;
 uint8_t RFIDReader = RFID_READER;                                           // RFID Reader (0:Disabled / 1:Enabled / 2:Enable One / 3:Learn / 4:Delete / 5:Delete All)
+#ifdef FAKE_RFID
+uint8_t Show_RFID = 0;
+#endif
 uint8_t WIFImode = WIFI_MODE;                                               // WiFi Mode (0:Disabled / 1:Enabled / 2:Start Portal)
 String APpassword = "00000000";
 
@@ -2832,7 +2836,7 @@ void StartwebServer(void) {
 
         if (RFIDReader) {
             switch(RFIDstatus) {
-                case 0:
+                case 0: doc["evse"]["rfid"] = "Ready to read card"; break;
                 case 1: doc["evse"]["rfid"] = "Present"; break;
                 case 2: doc["evse"]["rfid"] = "Card Stored"; break;
                 case 3: doc["evse"]["rfid"] = "Card Deleted"; break;
@@ -3064,6 +3068,17 @@ void StartwebServer(void) {
 
     },[](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final){
     });
+
+#ifdef FAKE_RFID
+    //this can be activated by: http://smartevse-xxx.lan/debug?showrfid=1
+    webServer.on("/debug", HTTP_GET, [](AsyncWebServerRequest *request) {
+        if(request->hasParam("showrfid")) {
+            Show_RFID = strtol(request->getParam("showrfid")->value().c_str(),NULL,0);
+        }
+        _Serialprintf("DEBUG: Show_RFID=%u.\n",Show_RFID);
+        request->send(200, "text/html", "Finished request");
+    });
+#endif
 
     // attach filesystem root at URL /
     webServer.serveStatic("/", SPIFFS, "/");


### PR DESCRIPTION
…D reader

To debug RFID problems without a RFID reader:
1) in include/evse.h, uncomment 
//#define FAKE_RFID 1  

2) now if you fire 
http://smartevse-xxx.lan/debug?showrfid=1

...SmartEVSE will act as if a card is shown for approx. 1 second . The card has id = 0x01 0x02 0x03 0x04 0x05 0x06 and can be stored, deleted etc.