### PR TITLE
evse.cpp: fix meter config bug when switching modes

### DIFF
--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -2532,8 +2532,6 @@ void validate_settings(void) {
     else if (Switch != 1 && Switch != 2) Access_bit = 1;
     // Sensorbox v2 has always address 0x0A
     if (MainsMeter == EM_SENSORBOX) MainsMeterAddress = 0x0A;
-    // Disable modbus reception on normal mode
-    if (Mode == MODE_NORMAL) { MainsMeter = 0; PVMeter = 0; }
     // Disable PV reception if not configured
     if (MainsMeterMeasure == 0) PVMeter = 0;
     // set Lock variables for Solenoid or Motor


### PR DESCRIPTION
When switching to normal mode, and then back to normal, the configuration of the MainsMeter is changed back to the default.
This PR fixes that bug. The line deleted does not prevent any modbus traffic, probably some remnant of a thought that never became code....