### PR TITLE
add basic MQTT read and write support, add /evmeter endpoint to API

### DIFF
--- a/SmartEVSE-3/.gitignore
+++ b/SmartEVSE-3/.gitignore
@@ -3,3 +3,5 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+cmake-build-debug
+build

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -65,6 +65,7 @@
             $('#car_connected').text(data.car_connected ? "Yes" : "No");
             $('#state').text(data.evse.state);
             $('#temp').text(data.evse.temp + " °C / " + data.evse.temp_max + " °C");
+            $('#mqtt').text(data.mqtt.status);
             if(data.evse.error != "None") {
               $('#error').text(data.evse.error);
               $('[id=with_errors]').show();
@@ -221,6 +222,14 @@
                                             </div>
                                             <div class="col">
                                               <div class="h5 mb-0 mr-3 text-gray-800" id="temp"></div>
+                                            </div>
+                                        </div>
+                                        <div class="row no-gutters align-items-center">
+                                            <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
+                                                MQTT:
+                                            </div>
+                                            <div class="col">
+                                                <div class="h5 mb-0 mr-3 text-gray-800" id="mqtt"></div>
                                             </div>
                                         </div>
                                     </div>

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -66,6 +66,7 @@
             $('#state').text(data.evse.state);
             $('#temp').text(data.evse.temp + " °C / " + data.evse.temp_max + " °C");
             $('#mqtt').text(data.mqtt.status);
+            $('#uptime').text(data.uptime);
 
             if(data.evse.rfid != "Not Installed") {
               $('#rfid').text(data.evse.rfid);
@@ -176,6 +177,14 @@
                                             </div>
                                             <div class="col">
                                               <div class="h5 mb-0 mr-3 text-gray-800" id="mode"></div>
+                                            </div>
+                                        </div>
+                                        <div class="row no-gutters align-items-center">
+                                            <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
+                                                Uptime:
+                                            </div>
+                                            <div class="col">
+                                                <div class="h5 mb-0 mr-3 text-gray-800" id="uptime"></div>
                                             </div>
                                         </div>
                                         <div class="row no-gutters align-items-center">

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -66,12 +66,6 @@
             $('#state').text(data.evse.state);
             $('#temp').text(data.evse.temp + " °C / " + data.evse.temp_max + " °C");
             $('#mqtt').text(data.mqtt.status);
-            if(data.evse.error != "None") {
-              $('#error').text(data.evse.error);
-              $('[id=with_errors]').show();
-            } else {
-              $('[id=with_errors]').hide();
-            }
 
             if(data.evse.rfid != "Not Installed") {
               $('#rfid').text(data.evse.rfid);
@@ -198,14 +192,6 @@
                                             </div>
                                             <div class="col">
                                               <div class="h5 mb-0 mr-3 text-gray-800" id="state"></div>
-                                            </div>
-                                        </div>
-                                        <div class="row no-gutters align-items-center" id="with_errors">
-                                          <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
-                                              Error:
-                                            </div>
-                                            <div class="col">
-                                              <div class="h5 mb-0 mr-3 text-gray-800" id="error"></div>
                                             </div>
                                         </div>
                                         <div class="row no-gutters align-items-center" id="show_rfid">

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -24,12 +24,12 @@
       let endpoint = document.location + 'settings';
       // let endpoint = 'http://10.0.0.36/settings';
       let initiated=false;
+      let mqttEditMode = false;
 
       $(document).ready(loadData());
 
-
       function loadData(){
-        $.ajax({
+          $.ajax({
               url: endpoint
           }).then(function(data) {
             if(!initiated) {
@@ -115,9 +115,9 @@
             }
 
             if(data.home_battery.last_update == 0) {
-              $('[id=with_homebattery]').hide();
+              $('.with_homebattery').hide();
             } else {
-              $('[id=with_homebattery]').show();
+              $('.with_homebattery').show();
             }
 
             if(data.home_battery.current == 0) {
@@ -135,6 +135,14 @@
             $('#evmeter_description').text(data.ev_meter.description);
             $('#evmeter_total_kwh').text(data.ev_meter.total_kwh.toFixed(1) + "kWh");
             $('#evmeter_charged_kwh').text(data.ev_meter.charged_kwh.toFixed(1) + "kWh");
+
+            if (!mqttEditMode) {
+                $('#mqtt_broker_ip').val(data.settings.mqtt_broker_ip);
+                $('#mqtt_broker_port').val(data.settings.mqtt_broker_port);
+                $('#mqtt_user').val(data.settings.mqtt_user);
+                $('#mqtt_password').val(data.settings.mqtt_password);
+                $('#mqtt_topic_prefix').val(data.settings.mqtt_topic_prefix);
+            }
 
             setTimeout("loadData()", 5000);
           });
@@ -367,7 +375,7 @@
                     </div>
                 </div>
 
-                <div class="col-xl-3 col-md-6 mb-4" id="with_homebattery">
+                <div class="col-xl-3 col-md-6 mb-4 with_homebattery">
                   <div class="card border-left-success shadow h-100 py-2">
                       <div class="card-body">
                           <div class="row no-gutters align-items-center">
@@ -472,7 +480,7 @@
               </div>
 
 
-              <div class="col-xl-3 col-md-6 mb-4" id="with_homebattery" style="display: none;">
+              <div class="col-xl-3 col-md-6 mb-4 with_homebattery" style="display: none;">
                 <div class="card border-left-warning shadow h-100 py-2">
                     <div class="card-body">
                         <div class="row no-gutters align-items-center">
@@ -534,6 +542,32 @@
                         $.post( "/settings?mode=" + mode);
                       }
                     }
+                    function toggleMqttEdit() {
+                        mqttEditMode = !mqttEditMode;
+                        $('.mqtt_settings').toggle();
+                        if (mqttEditMode) {
+                            $('#edit_mqtt_button').text("Close Settings")
+                        } else {
+                            $('#edit_mqtt_button').text("Edit Settings")
+                        }
+                    }
+                    function configureMqtt() {
+                        var mqtt_broker_ip=$('#mqtt_broker_ip').val();
+                        var mqtt_broker_port=$('#mqtt_broker_port').val();
+                        var mqtt_user=$('#mqtt_user').val();
+                        var mqtt_password=$('#mqtt_password').val();
+                        var mqtt_topic_prefix=$('#mqtt_topic_prefix').val();
+
+                        if (mqtt_broker_ip && mqtt_broker_port) {
+                            $.post( "/settings?mqtt_broker_ip=" + mqtt_broker_ip +
+                                "&mqtt_broker_port=" + mqtt_broker_port + "&mqtt_user=" + mqtt_user +
+                                "&mqtt_password=" + mqtt_password + "&mqtt_topic_prefix=" + mqtt_topic_prefix);
+                            alert('Settings applied');
+                            toggleMqttEdit();
+                        } else {
+                            alert('Missing broker IP or port');
+                        }
+                    }
                     function reboot() {
                         $.post( "/reboot");
                     }
@@ -583,19 +617,42 @@
                                           <button onclick="rawData()" style="width: 120px; display:inline-block;">Raw Data</button>
                                         </div>
                                     </div>
-
-                                  </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
-
-                
-
+              </div>
+              <div class="row">
+                  <div style="margin-bottom: 20px;">
+                      <div class="card border-left-primary shadow h-100 py-2">
+                        <div class="card-body">
+                            <div class="row no-gutters align-items-center">
+                                <div class="col mr-2">
+                                    <div class="text font-weight-bold text-primary text-uppercase mb-1">Settings</div>
+                                    <div class="row no-gutters align-items-center">
+                                        <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
+                                            MQTT:
+                                        </div>
+                                        <div class="col">
+                                            <button onclick="toggleMqttEdit()" style="display:inline-block;" id="edit_mqtt_button">Edit Settings</button>
+                                            <div class="mqtt_settings" style="display:none">
+                                                <label>Broker IP: <input id="mqtt_broker_ip"></label>
+                                                <label>Broker Port: <input id="mqtt_broker_port"></label>
+                                                <label>User: <input id="mqtt_user"></label>
+                                                <label>Password: <input id="mqtt_password"></label>
+                                                <label>Topic Prefix: <input id="mqtt_topic_prefix"></label>
+                                                <button onclick="configureMqtt()" style="display:inline-block;">Save</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                  </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                  </div>
                 </div>
-                <!-- END ROW -->
-          
             </div>
         </div>
       </div>

--- a/SmartEVSE-3/include/ReconnectingMQTTClient.h
+++ b/SmartEVSE-3/include/ReconnectingMQTTClient.h
@@ -1,0 +1,454 @@
+/*
+;	 Project:       Smart EVSE
+;
+;
+ Copyright 2019-2020 Fred Larsen
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef __RECONNECTING_MQTT_CLIENT
+#define __RECONNECTING_MQTT_CLIENT
+
+#pragma once
+// Based on the spec http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718016
+
+#include <PJONEthernetTCP.h>
+
+#ifndef ARDUINO
+#include <string>
+#define String std::string
+#endif
+
+#ifndef SMCBUFSIZE
+#ifdef ARDUINO
+#define SMCBUFSIZE 100
+#else
+#define SMCBUFSIZE 1000
+#endif
+#endif
+#ifndef SMCTOPICSIZE
+#ifdef ARDUINO
+#define SMCTOPICSIZE 50
+#else
+#define SMCTOPICSIZE 100
+#endif
+#endif
+
+typedef void(*RMCReceiveCallback)(
+        const char     *topic,
+        const uint8_t  *payload,
+        uint16_t len,
+        void     *custom_ptr
+);
+
+class ReconnectingMqttClient {
+public:
+    // Fixed byte sequences
+    const uint8_t CONNECT = 1 << 4,
+            CONNACK =             2 << 4,
+            PUBLISH =             3 << 4,
+            PUBACK =              4 << 4,
+            SUBSCRIBE =          (8 << 4) | 2, // 0b10000010
+    SUBACK =              9 << 4,
+            UNSUBSCRIBE =       (10 << 4) | 2, // 0b10100010
+    UNSUBACK =           11 << 4,
+            PINGREQ_2[2] =     { 12 << 4, 0 },
+            PINGRESP_2[2] =    { 13 << 4, 0 },
+            DISCONNECT_2[2] =  { 14 << 4, 0 },
+            CONNECT_7[7] = { 0x00,0x04,'M','Q','T','T',0x04 }; // MQTT version 4 = 3.1.1
+
+    const uint16_t KEEPALIVE_S = 60, PING_TIMEOUT = 15000;
+    const uint32_t READ_TIMEOUT = 10000;
+
+    String topic, client_id, user, password;
+    uint8_t server_ip[4], sub_qos = 1;
+    uint16_t port = 1883;
+
+    TCPHelperClient client;
+    bool enabled = true;
+    uint16_t msg_id = 1, pubacked_msg_id = 0;
+    bool waiting_for_ping = false;
+    uint32_t last_packet_in = 0, last_packet_out = 0;
+    int8_t last_connect_error = 0x7F; // Unknown
+    RMCReceiveCallback receive_callback = NULL;
+    void *custom_ptr = NULL; // Custom data for the callback, for example a pointer to a derived class object
+    char topicbuf[SMCTOPICSIZE];
+    uint8_t buffer[SMCBUFSIZE];
+    volatile bool last_sub_acked = false, last_pub_acked = false; // With QoS 1 the success of the last SUB or PUB can be checked
+
+    void init_system() {
+#ifdef _WIN32
+        WSAData wsaData; WSAStartup(MAKEWORD(2, 2), &wsaData); // Load Winsock
+#endif
+    }
+
+    void cleanup_system() {
+#ifdef _WIN32
+        WSACleanup(); // Cleanup Winsock
+#endif
+    }
+
+    void response_delay() {
+#ifndef PJON_ESP
+        client.flush();
+#endif
+#ifdef ARDUINO
+        yield();
+#endif
+    }
+
+    // Portable alternative to itoa which is not available everywhere, Returns chars added.
+    uint8_t uint8toa(uint8_t n, char *p) {
+        uint8_t a = n/100, b = (n % 100)/10, c = n % 10;
+        char *p2 = p;
+        if (a!=0) *p2++ = '0' + a;
+        if (b!=0) *p2++ = '0' + b;
+        *p2++ = '0' + c;
+        *p2 = 0; // Null-terminate
+        return p2-p;
+    }
+
+    // Write a header into the start of the buffer and return the number of bytes written
+    uint16_t put_header(const uint8_t header, uint8_t *buf, const uint16_t len) {
+        uint16_t l = len;
+        uint8_t pos = 0, v;
+        buf[pos++] = header;
+        do { v = l % 0x80; l /= 0x80; buf[pos++] = l > 0 ? v | 0x80 : v; } while (l != 0);
+        return pos;
+    }
+
+    // Write an UTF-8 text into the buffer at the given offset, return number of bytes written
+    uint16_t put_string(const char *text, uint16_t len, uint8_t *buf, const uint16_t pos) {
+        uint16_t p = pos;
+        if (len == 0) return 0;
+        buf[p++] = len >> 8;
+        buf[p++] = len & 0xFF;
+        memcpy(&buf[p], text, len);
+        return 2 + len;
+    }
+    uint16_t put_string(const char *text, uint8_t *buf, const uint16_t pos) {
+        return put_string(text, (uint16_t) strlen(text), buf, pos);
+    }
+
+    bool send_disconnect() { return write_to_socket(DISCONNECT_2, 2); }
+    bool send_pingreq() { waiting_for_ping = true; return write_to_socket(PINGREQ_2, 2); }
+    bool send_pingresp() { return write_to_socket(PINGRESP_2, 2); }
+
+    uint32_t inactivity_time() {
+        uint32_t in = last_packet_in == 0 ? 1000000000 : (uint32_t)(millis() - last_packet_in),
+                out = last_packet_out == 0 ? 1000000000 : (uint32_t)(millis() - last_packet_out);
+        return in < out ? in : out;
+    }
+
+    bool write_to_socket(const uint8_t *buf, const uint16_t len) {
+        if (client.connected()) {
+            uint16_t remain = len;
+            while (remain > 0) {
+                int written = client.write(buf, remain);
+                if (written <= 0) break;
+                remain -= written;
+            }
+            bool ok = remain == 0;
+#ifdef MQTT_DEBUGPRINT
+            printf("%u Sent packet %u len %d\n", millis(), buf[0], len);
+#endif
+            if (ok) last_packet_out = millis();
+            return ok;
+        }
+        return false;
+    }
+
+    bool read_from_socket(uint8_t *buf, const uint16_t len, const uint16_t startpos = 0, bool blocking = true) {
+        if (client.connected()) {
+            uint16_t remain = len, pos = startpos;
+            uint32_t start = millis();
+            while (remain > 0) {
+                int n = client.read(&buf[pos], remain);
+#if defined(PJON_ESP) && defined(ESP32)
+                if (n == -1) n = 0; // ESP32 returns -1 if nothing there, not only if connection broken
+#else
+                if (n == -1) break; // Normal behavior, -1 = error, connection broken
+#endif
+                if (n == 0 && (uint32_t)(millis() - start) > READ_TIMEOUT) break;
+                if (!blocking && n == 0 && remain == len) break; // available() sometimes gives false positive, exit if nothing
+                if (n == 0) delay(1);
+                remain -= n;
+            }
+            return remain == 0;
+        }
+        return false;
+    }
+
+    bool read_packet_from_socket(uint8_t *buf, const uint16_t bufsize, uint16_t &packet_len,
+                                 uint16_t &payload_len, bool blocking = true) {
+        packet_len = payload_len = buf[0] = 0;
+        if (!read_from_socket(buf, 2, 0, blocking)) return false;
+        payload_len = buf[1] & 0x7F; // Remove upper bit
+        uint16_t pos = 2;
+        // Read length of payload
+        uint32_t scaling = 1;
+        while (buf[pos - 1] & 0x80) { // If uppermost bit is set
+            if (!read_from_socket(buf, 1, pos++)) return false;
+            scaling *= 0x80;
+            payload_len += (buf[pos - 1] & 0x7F)*scaling;
+        }
+        // Read payload
+        if (payload_len > 0) {
+            if (pos + payload_len >= bufsize) return false; // Too big
+            if (!read_from_socket(buf, payload_len, pos)) return false;
+            pos += payload_len;
+            buf[pos] = 0; // Null-terminate after payload to simplify usage if text
+        }
+        packet_len = pos;
+        last_packet_in = millis();
+#ifdef MQTT_DEBUGPRINT
+        printf("%u Received packet %u len %d\n", millis(), buf[0], packet_len);
+#endif
+        return packet_len > 1;
+    }
+
+    bool socket_connect() {
+        if (!client.connect(server_ip, port)) { delay(100); return false; }
+
+        // Compose packet
+        uint16_t len = 0, payloadsize = (uint16_t) (10 + (client_id.length() + 2)
+                                                    + (user.length() > 0 ? user.length() + 2 : 0)
+                                                    + (password.length() > 0 ? password.length() + 2 : 0));
+        len += put_header(CONNECT, buffer, payloadsize);
+        memcpy(&buffer[len], CONNECT_7, 7);
+        len += 7;
+        uint8_t flags = 0x02; // Clean session, No will
+        if (user.length() > 0) flags |= password.length() > 0 ? 0x80 | (0x80 >> 1) : 0x80;
+        buffer[len++] = flags;
+        buffer[len++] = KEEPALIVE_S >> 8;
+        buffer[len++] = KEEPALIVE_S & 0xFF;
+        len += put_string(client_id.c_str(), buffer, len);
+        len += put_string(user.c_str(), buffer, len);
+        len += put_string(password.c_str(), buffer, len);
+        last_connect_error = 0x7F;
+        last_packet_in = millis();
+        if (write_to_socket(buffer, len)) {
+            response_delay();
+            uint16_t packet_len, payload_len;
+            if (read_packet_from_socket(buffer, sizeof buffer, packet_len, payload_len)) {
+                if (packet_len == 4 && buffer[0] == CONNACK) {
+                    if (buffer[3] == 0) {
+                        // Subscribe if a topic has been set
+                        if (topic.length() > 0) {
+                            bool ok = send_subscribe(topic.c_str(), sub_qos);
+                            if (!ok) stop();
+                        }
+                        return client.connected();
+                    }
+                    else last_connect_error = buffer[3]; // Got an error code
+                }
+            }
+        }
+        return false;
+    }
+
+    void handle_publish(const uint8_t *buf, const uint16_t packet_len, const uint16_t payload_len) {
+        if (receive_callback) {
+            uint16_t pos = packet_len - payload_len;
+            uint8_t s0 = buf[pos++], s1 = buf[pos++];
+            uint16_t textlen = (s0 << 8) | s1;
+            memcpy(topicbuf, &buf[pos], textlen);
+            topicbuf[textlen] = 0; // Null terminator
+            pos += textlen;
+
+            if (buf[0] & 0b00000110) { // QOS1 or QOS2
+                uint8_t sendbuf[4];
+                sendbuf[0] = PUBACK;
+                sendbuf[1] = 2;
+                sendbuf[2] = buf[pos++]; // message id MSB
+                sendbuf[3] = buf[pos++]; // message id LSB
+                write_to_socket(sendbuf, 4);
+            }
+            receive_callback(topicbuf, &buf[pos], packet_len - pos, custom_ptr);
+        }
+    }
+
+    void send_ping_if_needed() {
+        if (inactivity_time() > PING_TIMEOUT) {
+            if (waiting_for_ping) { stop(); start(); } else send_pingreq();
+        }
+    }
+
+    const char *next_topic(const char *p) { while (*p && *p != ',') p++; return p; }
+
+    bool send_subscribe(const char *topic, const uint8_t qos, bool unsubscribe = false) {
+        last_sub_acked = false;
+        if (client.connected()) {
+            // Pre-scan to find total payload length
+            uint16_t payload_len = 2; // packet identifier
+            const char *p = topic, *p2 = p;
+            while (*p && (p2 = next_topic(p))) { // Find next comma or final null-terminator
+                payload_len += ((uint16_t)(p2-p) + 2) + (unsubscribe ? 0 : 1);
+                p = *p2 ? p2 + 1 : p2; // Skip comma if several topics are listed
+            }
+            // Add header and packet identifier
+            uint16_t len = put_header(unsubscribe ? UNSUBSCRIBE : SUBSCRIBE, buffer, payload_len);
+            if (++msg_id == 0) msg_id++; // Avoid 0
+            buffer[len++] = msg_id >> 8;
+            buffer[len++] = msg_id & 0xFF;
+            // Add each topic
+            p = topic;
+            while (*p && (p2 = next_topic(p))) {
+                payload_len += ((uint16_t)(p2-p) + 2) + (unsubscribe ? 0 : 1);
+                len += put_string(p, (uint16_t)(p2-p), buffer, len);
+                if (!unsubscribe) buffer[len++] = qos;
+                p = *p2 ? p2 + 1 : p2; // Skip comma if several topics are listed
+            }
+            return write_to_socket(buffer, len);
+        }
+        return false;
+    }
+
+    void handle_suback(const uint8_t *buf, const uint16_t packet_len, const uint16_t payload_len, bool unsubscribe) {
+        if (packet_len == (unsubscribe ? 4 : 5) && buf[0] == (unsubscribe ? UNSUBACK : SUBACK)) {
+            uint16_t mess_id = (buf[2] << 8) | buf[3];
+            if (!unsubscribe && buf[4] > 2) return; // Return code indicates failure
+            if (mess_id == msg_id) last_sub_acked = true;
+        }
+    }
+
+    void handle_puback(const uint8_t *buf, const uint16_t packet_len, const uint16_t payload_len) {
+        if (packet_len == 4 && buf[0] == PUBACK) {
+            pubacked_msg_id = (buf[2] << 8) | buf[3];
+            if (pubacked_msg_id == msg_id) last_pub_acked = true;
+        }
+    }
+
+public:
+    ReconnectingMqttClient() {}
+    ReconnectingMqttClient(const uint8_t server_ip[4], const uint16_t server_port, const char *client_id) {
+        set_address(server_ip, server_port, client_id);
+    }
+    ReconnectingMqttClient(const uint8_t server_ip[4], const uint16_t server_port, const char *client_id, const char *user, const char *password) {
+        set_credentials(user, password);
+        set_address(server_ip, server_port, client_id);
+    }
+    ~ReconnectingMqttClient() { stop(); }
+
+    void set_address(const uint8_t server_ip[4], const uint16_t server_port, const char *client_id) {
+        if (server_ip[0] == 0 && server_ip[1] == 0 && server_ip[2] == 0 && server_ip[3] == 0) {
+            enabled = false;
+            return;
+        }
+        memcpy(this->server_ip, server_ip, 4); port = server_port; this->client_id = client_id; start();
+    }
+    void set_credentials(const char *user, const char *password) {
+        this->user = user; this->password = password;
+    }
+    void set_receive_callback(RMCReceiveCallback callback, void *custom_pointer) {
+        receive_callback = callback; custom_ptr = custom_pointer;
+    }
+
+    bool publish(const char *topic, const uint8_t *payload, const uint16_t payloadlen, const  bool retain, const uint8_t qos = 0) {
+        last_pub_acked = false;
+        if (connect()) {
+            uint16_t total = ((uint16_t) strlen(topic) + 2) + (qos > 0 ? 2 : 0) + payloadlen,
+                    len = put_header(PUBLISH, buffer, total);
+            if (retain) buffer[0] |= 1;
+            buffer[0] |= qos << 1; // Add QOS into second or third bit
+            len += put_string(topic, buffer, len);
+            if (qos > 0) {
+                if (++msg_id == 0) msg_id++;
+                buffer[len++] = msg_id >> 8;
+                buffer[len++] = msg_id & 0xFF;
+            }
+            memcpy(&buffer[len], payload, payloadlen);
+            len += payloadlen;
+            bool ok = write_to_socket(buffer, len);
+            if (qos == 0) last_pub_acked = ok;
+            return ok;
+        }
+        return false;
+    }
+
+    // Text-only version for convenience
+    bool publish(const char *topic, const char *payload, const  bool retain, const uint8_t qos = 0) {
+        return publish(topic, (const uint8_t*)payload, (uint16_t)strlen(payload), retain, qos);
+    }
+
+    // When subscribing, multiple topics can be listed separated by comma
+    bool subscribe(const char *topic, const uint8_t qos = 1) {
+        if (this->topic.c_str()[0]) unsubscribe();
+        this->topic = topic;
+        sub_qos = qos;
+        return send_subscribe(this->topic.c_str(), qos, false);
+    }
+    bool unsubscribe() {
+        bool ok = send_subscribe(this->topic.c_str(), 0, true);
+        this->topic = "";
+        return ok;
+    }
+
+    void update() {
+        if (connect()) {
+            send_ping_if_needed();
+#ifdef ARDUINO
+            yield();
+#endif
+            int16_t avail = client.available();
+            if (avail > 0) {
+                uint16_t packet_len, payload_len;
+                if (read_packet_from_socket(buffer, sizeof buffer, packet_len, payload_len, false) && packet_len > 1) {
+                    if ((buffer[0] & PUBLISH) == PUBLISH) handle_publish(buffer, packet_len, payload_len);
+                    else if (buffer[0] == PUBACK) handle_puback(buffer, packet_len, payload_len);
+                    else if (buffer[0] == SUBACK) handle_suback(buffer, packet_len, payload_len, false);
+                    else if (buffer[0] == UNSUBACK) handle_suback(buffer, packet_len, payload_len, true);
+                    else if (buffer[0] == PINGREQ_2[0]) send_pingresp();
+                    else if (buffer[0] == PINGRESP_2[0]) waiting_for_ping = false;
+#ifdef MQTT_DEBUGPRINT
+                    else printf("%u Received UNKNOWN packet %u len %d\n", millis(), buffer[0], packet_len);
+#endif
+                }
+            }
+        }
+    }
+
+    void start() { enabled = true; last_packet_in = last_packet_out = millis(); init_system(); }
+    void stop() {
+        if (this->topic.length() > 0) send_subscribe(this->topic.c_str(), true);
+        send_disconnect();
+        client.stop();
+        enabled = false;
+        cleanup_system();
+    }
+
+    bool connect() {
+        if (!client.connected() && enabled) return socket_connect();
+        return client.connected();
+    }
+    bool is_connected() { if (!client.connected()) client.stop(); return client.connected(); }
+    bool is_enabled() { return enabled; }
+
+    // The subscribe call and the publish calls With QoS 1 will return true or false depending on whether
+    // the message was written, not whether an ACK was received. This can be checked here, and it may be set
+    // not immediately but some time later. Other packets may be received before the ACK arrives.
+    bool was_last_sub_acked() const { return last_sub_acked; }
+    bool was_last_pub_acked() const { return last_pub_acked; }
+    uint16_t last_pub_msgid() const { return msg_id; }
+    uint16_t last_puback_msgid() const { return pubacked_msg_id; }
+    bool wait_for_puback(uint16_t timeout_ms = 100) {
+        uint32_t start = millis();
+        while (!was_last_pub_acked() && ((uint32_t)(millis()-start)<timeout_ms)) update();
+        return was_last_pub_acked();
+    }
+
+    char *topic_buf() { return topicbuf; } // Allow temporary access for composing outgoing topic, saving memory
+};
+
+#endif //RECONNECTING_MQTT_CLIENT

--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -25,7 +25,7 @@
 
 #define __EVSE_MAIN
 
-#define MQTT true // enable or disable MQTT
+#define MQTT 1 // enable or disable MQTT code
 
 //for wifi-debugging, don't forget to set the debug levels LOG_EVSE_LOG and LOG_MODBUS_LOG before compiling
 //the wifi-debugger is available by telnetting to your SmartEVSE device

--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -25,6 +25,7 @@
 
 #define __EVSE_MAIN
 
+#define MQTT true // enable or disable MQTT
 
 //for wifi-debugging, don't forget to set the debug levels LOG_EVSE_LOG and LOG_MODBUS_LOG before compiling
 //the wifi-debugger is available by telnetting to your SmartEVSE device

--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -164,6 +164,7 @@ extern RemoteDebug Debug;
 #define AP_PASSWORD "00000000"
 #define USE_3PHASES 0
 #define MAX_TEMPERATURE 65
+#define DEFAULT_ACCESS 1
 
 
 // Mode settings
@@ -309,8 +310,9 @@ extern RemoteDebug Debug;
 #define MENU_EMCUSTOM_READMAX 36                                                // 0x0218: Maximum register read (ToDo)
 #define MENU_WIFI 37                                                            // 0x0219: WiFi mode
 #define MENU_3F 38
-#define MENU_MAX_TEMP 39
-#define MENU_EXIT 40
+#define MENU_DEFAULT_ACCESS 39
+#define MENU_MAX_TEMP 40
+#define MENU_EXIT 41
 
 #define MENU_STATE 50
 
@@ -435,6 +437,7 @@ extern bool LocalTimeSet;
 extern uint8_t MenuItems[MENU_EXIT];
 extern boolean enable3f;
 extern uint16_t maxTemp;
+extern boolean defaultAccess;
 extern uint8_t ExternalMaster;
 
 const struct {
@@ -489,8 +492,9 @@ const struct {
     {"EMEDIV", "ENE DIVI","Divisor for Energy (kWh) of custom electric meter",  0, 7, EMCUSTOM_EDIVISOR},
     {"EMREAD", "READ MAX","Max register read at once of custom electric meter", 3, 255, 3},
     {"WIFI",   "WIFI",    "Connect to WiFi access point",                       0, 2, WIFI_MODE},
-    {"EV3P",   "3 PHASE",  "Can EV use 3 phases",                               0, 1, USE_3PHASES},
-    {"MXTMP",  "MAX TEMP",  "Maximum temperature for the EVSE module",          40, 75, MAX_TEMPERATURE},
+    {"EV3P",   "3 PHASE", "Can EV use 3 phases",                                0, 1, USE_3PHASES},
+    {"DACCE",  "ACCESS",  "Default access setting",                             0, 1, DEFAULT_ACCESS},
+    {"MXTMP",  "MAX TEMP", "Maximum temperature for the EVSE module",           40, 75, MAX_TEMPERATURE},
 
     {"EXIT", "EXIT", "EXIT", 0, 0, 0}
 };

--- a/SmartEVSE-3/platformio.ini
+++ b/SmartEVSE-3/platformio.ini
@@ -30,7 +30,8 @@ lib_deps =
 	khoih-prog/ESPAsync_WiFiManager@1.9.8
 	miq19/eModbus@1.4.1
 	bblanchon/ArduinoJson@^6.19.3
-	
+	gioblu/PJON@^13.0
+
 monitor_filters = esp32_exception_decoder
 board_build.partitions = partitions_custom.csv
 

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -134,6 +134,7 @@ String APpassword = "00000000";
 
 boolean enable3f = USE_3PHASES;
 uint16_t maxTemp = MAX_TEMPERATURE;
+boolean defaultAccess = DEFAULT_ACCESS;
 
 int32_t Irms[3]={0, 0, 0};                                                  // Momentary current per Phase (23 = 2.3A) (resolution 100mA)
 int32_t Irms_EV[3]={0, 0, 0};                                               // Momentary current per Phase (23 = 2.3A) (resolution 100mA)
@@ -647,7 +648,7 @@ void setState(uint8_t NewState, bool forceState) {
 
 void setAccess(bool Access) {
     Access_bit = Access;
-    if (Access == 0) {
+    if (!Access) {
         if (State == STATE_C) setState(STATE_C1);                               // Determine where to switch to.
         else if (State == STATE_B) setState(STATE_B1);
     }
@@ -1082,6 +1083,9 @@ uint8_t setItemValue(uint8_t nav, uint16_t val) {
         case MENU_MAX_TEMP:
             maxTemp = val;
             break;
+        case MENU_DEFAULT_ACCESS:
+            defaultAccess = val == 1;
+            break;
         case MENU_3F:
             enable3f = val == 1;
             break;
@@ -1243,6 +1247,8 @@ uint16_t getItemValue(uint8_t nav) {
     switch (nav) {
         case MENU_MAX_TEMP:
             return maxTemp;
+        case MENU_DEFAULT_ACCESS:
+            return defaultAccess;
         case MENU_3F:
             return enable3f;
         case MENU_CONFIG:
@@ -2611,8 +2617,6 @@ void validate_settings(void) {
 
     // RFID reader set to Enable One card, the EVSE is disabled by default
     if (RFIDReader == 2) Access_bit = 0;
-    // Enable access if no access switch used
-    else if (Switch != 1 && Switch != 2) Access_bit = 1;
     // Sensorbox v2 has always address 0x0A
     if (MainsMeter == EM_SENSORBOX) MainsMeterAddress = 0x0A;
     // Disable PV reception if not configured
@@ -2691,6 +2695,7 @@ void read_settings(bool write) {
 
         enable3f = preferences.getUChar("enable3f", false); 
         maxTemp = preferences.getUShort("maxTemp", MAX_TEMPERATURE);
+        defaultAccess = preferences.getUChar("defaultAccess", DEFAULT_ACCESS);
 
 #ifdef MQTT
         MQTTpassword = preferences.getString("MQTTpassword");
@@ -2753,6 +2758,7 @@ void write_settings(void) {
 
     preferences.putBool("enable3f", enable3f);
     preferences.putUShort("maxTemp", maxTemp);
+    preferences.putBool("defaultAccess", defaultAccess);
 
 #ifdef MQTT
     preferences.putString("MQTTpassword", MQTTpassword);
@@ -3834,6 +3840,9 @@ void setup() {
   
     BacklightTimer = BACKLIGHT;
     GLCD_init();
+
+    // Set Access_bit from defaultAccess setting on boot
+    Access_bit = defaultAccess;
           
 }
 

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -3403,45 +3403,6 @@ void StartwebServer(void) {
     },[](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final){
     });
 
-    webServer.on("/currents", HTTP_POST, [](AsyncWebServerRequest *request) {
-        DynamicJsonDocument doc(200);
-
-        if(request->hasParam("battery_current")) {
-            String value = request->getParam("battery_current")->value();
-            homeBatteryCurrent = value.toInt();
-            homeBatteryLastUpdate = time(NULL);
-            doc["battery_current"] = homeBatteryCurrent;
-        }
-
-        if(MainsMeter == EM_API) {
-            if(request->hasParam("L1") && request->hasParam("L2") && request->hasParam("L3")) {
-                phasesLastUpdate = time(NULL);
-
-                Irms[0] = request->getParam("L1")->value().toInt();
-                Irms[1] = request->getParam("L2")->value().toInt();
-                Irms[2] = request->getParam("L3")->value().toInt();
-
-                int batteryPerPhase = getBatteryCurrent() / 3;
-                Isum = 0; 
-                for (int x = 0; x < 3; x++) {  
-                    IrmsOriginal[x] = Irms[x];
-                    doc["original"]["L" + x] = Irms[x];
-                    Irms[x] -= batteryPerPhase;           
-                    doc["L" + x] = Irms[x];
-                    Isum = Isum + Irms[x];
-                }
-                doc["TOTAL"] = Isum;
-                UpdateCurrentData();
-            }
-        }
-
-        String json;
-        serializeJson(doc, json);
-        request->send(200, "application/json", json);
-
-    },[](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final){
-    });
-
     webServer.on("/evmeter", HTTP_POST, [](AsyncWebServerRequest *request) {
         DynamicJsonDocument doc(200);
 
@@ -3460,19 +3421,6 @@ void StartwebServer(void) {
                 EnergyCharged = EnergyEV - EnergyMeterStart;                    // Calculate Energy
             }
         }
-
-        String json;
-        serializeJson(doc, json);
-        request->send(200, "application/json", json);
-
-    },[](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final){
-    });
-
-    webServer.on("/reboot", HTTP_POST, [](AsyncWebServerRequest *request) {
-        DynamicJsonDocument doc(200);
-
-        ESP.restart();
-        doc["reboot"] = true;
 
         String json;
         serializeJson(doc, json);

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -1220,9 +1220,7 @@ uint8_t setItemValue(uint8_t nav, uint16_t val) {
             setSolarStopTimer(val);
             break;
         case STATUS_ACCESS:
-            if (val == 0 || val == 1) {
-                setAccess(val);
-            }
+            setAccess(val == 1);
             break;
         case STATUS_CONFIG_CHANGED:
             ConfigChanged = val;
@@ -3261,20 +3259,20 @@ void StartwebServer(void) {
             String mode = request->getParam("mode")->value();
             switch(mode.toInt()) {
                 case 0: // OFF
-                    setAccess(0);
+                    setAccess(false);
                     break;
                 case 1:
-                    setAccess(1);
+                    setAccess(true);
                     setMode(MODE_NORMAL);
                     break;
                 case 2:
                     OverrideCurrent = 0;
-                    setAccess(1);
+                    setAccess(true);
                     setMode(MODE_SOLAR);
                     break;
                 case 3:
                     OverrideCurrent = 0;
-                    setAccess(1);
+                    setAccess(true);
                     setMode(MODE_SMART);
                     break;
                 default:

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -3188,8 +3188,8 @@ void StartwebServer(void) {
 #ifdef MQTT
         bool mqttChanged = false;
 
-        if(request->hasParam("mqttBrokerIp")) {
-            String inputMqttBrokerIp = request->getParam("mqttBrokerIp")->value();
+        if(request->hasParam("mqtt_broker_ip")) {
+            String inputMqttBrokerIp = request->getParam("mqtt_broker_ip")->value();
             if (!inputMqttBrokerIp || inputMqttBrokerIp == "") {
                 MQTTbrokerIp.fromString("0.0.0.0");
             } else {
@@ -3199,24 +3199,24 @@ void StartwebServer(void) {
             mqttChanged = true;
         }
 
-        if(request->hasParam("mqttBrokerPort")) {
-            MQTTbrokerPort = request->getParam("mqttBrokerPort")->value().toInt();
+        if(request->hasParam("mqtt_broker_port")) {
+            MQTTbrokerPort = request->getParam("mqtt_broker_port")->value().toInt();
             if (MQTTbrokerPort == 0) MQTTbrokerPort = 1883;
             doc["mqtt_broker_port"] = MQTTbrokerPort;
             mqttChanged = true;
         }
 
-        if(request->hasParam("mqttPrefix")) {
-            MQTTprefix = request->getParam("mqttPrefix")->value();
+        if(request->hasParam("mqtt_topic_prefix")) {
+            MQTTprefix = request->getParam("mqtt_topic_prefix")->value();
             if (!MQTTprefix || MQTTprefix == "") {
                 MQTTprefix = APhostname;
             }
-            doc["mqtt_prefix"] = MQTTprefix;
+            doc["mqtt_topic_prefix"] = MQTTprefix;
             mqttChanged = true;
         }
 
-        if(request->hasParam("mqttUser")) {
-            MQTTuser = request->getParam("mqttUser")->value();
+        if(request->hasParam("mqtt_user")) {
+            MQTTuser = request->getParam("mqtt_user")->value();
             if (!MQTTuser || MQTTuser == "") {
                 MQTTuser.clear();
             }
@@ -3224,9 +3224,9 @@ void StartwebServer(void) {
             mqttChanged = true;
         }
 
-        if(request->hasParam("mqttPassword")) {
-            MQTTpassword = request->getParam("mqttPassword")->value();
-            if (!MQTTpassword || MQTTpassword == "" || MQTTpassword == " ") {
+        if(request->hasParam("mqtt_password")) {
+            MQTTpassword = request->getParam("mqtt_password")->value();
+            if (!MQTTpassword || MQTTpassword == "") {
                 MQTTpassword.clear();
             }
             doc["mqtt_password_set"] = (MQTTpassword != "");

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -3049,8 +3049,18 @@ void StartwebServer(void) {
     });
 
     webServer.on("/settings", HTTP_GET, [](AsyncWebServerRequest *request) {
-        String mode = getModeNameWeb(Mode);
+        String mode = "N/A";
         int modeId = -1;
+        if(Access_bit == 0)  {
+           mode = "OFF";
+           modeId=0;
+        } else {
+           switch(Mode) {
+              case MODE_NORMAL: mode = "NORMAL"; modeId=1; break;
+              case MODE_SOLAR: mode = "SOLAR"; modeId=2; break;
+              case MODE_SMART: mode = "SMART"; modeId=3; break;
+           }
+        }
         String backlight = "N/A";
         switch(BacklightSet) {
             case 0: backlight = "OFF"; break;

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -2127,9 +2127,7 @@ void Timer1S(void * parameter) {
             } else {                                                        // Normal mode
                 Imeasured = 0;                                              // No measurements, so we set it to zero
                 ModbusRequest = 6;                                          // Start with state 5 (poll Nodes)
-                if (EVMeter != EM_API || phasesLastUpdate > (time(NULL) - 10)) {
-                    timeout = 10;                                               // reset timeout counter (not checked for Master)
-                }
+                timeout = 10;                                               // reset timeout counter (not checked for Master)
             }
             Broadcast = 1;                                                  // repeat every two seconds
         }
@@ -2836,12 +2834,14 @@ void mqtt_receive_callback(const char *topic, const uint8_t *payload, uint16_t l
        }
    } else if (stopic == MQTTprefix + "/Set/MainsMeter") {
       if (MainsMeter != EM_API) return;
+
       int32_t L1, L2, L3;
       int n = sscanf((char*)payload, "%d:%d:%d", &L1, &L2, &L3);
       _Serialprintf("MainsMeter MQTT received %d %d %d %d\n", n, L1, L2, L3);
 
       if (n == 3) {
          phasesLastUpdate = time(NULL);
+         if (LoadBl <2) timeout = 10;
 
          Irms[0] = L1;
          Irms[1] = L2;
@@ -3363,6 +3363,7 @@ void StartwebServer(void) {
         if(MainsMeter == EM_API) {
             if(request->hasParam("L1") && request->hasParam("L2") && request->hasParam("L3")) {
                 phasesLastUpdate = time(NULL);
+                if (LoadBl <2) timeout = 10;
 
                 Irms[0] = request->getParam("L1")->value().toInt();
                 Irms[1] = request->getParam("L2")->value().toInt();

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -629,7 +629,7 @@ void setState(uint8_t NewState, bool forceState) {
         case STATE_C:                                                           // State C2
             ActivationMode = 255;                                               // Disable ActivationMode
             CONTACTOR1_ON;      
-            if(Mode == MODE_NORMAL && enable3f)                                 // Contactor1 ON
+            if(Mode != MODE_SOLAR && enable3f)                                  // Contactor1 ON
                 CONTACTOR2_ON;                                                  // Contactor2 ON
             LCDTimer = 0;
             break;

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -2839,7 +2839,7 @@ void mqtt_receive_callback(const char *topic, const uint8_t *payload, uint16_t l
       int n = sscanf((char*)payload, "%d:%d:%d", &L1, &L2, &L3);
       _Serialprintf("MainsMeter MQTT received %d %d %d %d\n", n, L1, L2, L3);
 
-      if (n == 3) {
+      if (n == 3 && L1 < 1000 && L2 < 1000 && L3 < 1000) {
          phasesLastUpdate = time(NULL);
          if (LoadBl <2) timeout = 10;
 
@@ -2863,7 +2863,7 @@ void mqtt_receive_callback(const char *topic, const uint8_t *payload, uint16_t l
       int n = sscanf((char*)payload, "%d:%d:%d:%d:%d", &L1, &L2, &L3, &W, &WH);
       _Serialprintf("EVMeter MQTT received %d %d %d %d %d %d\n", n, L1, L2, L3, W, WH);
 
-      if (n == 5) {
+      if (n == 5 && L1 < 1000 && L2 < 1000 && L3 < 1000 && W < 100000) {
          evMeterLastUpdate = time(NULL);
          // Energy measurement
          EnergyEV = WH;

--- a/SmartEVSE-3/src/glcd.cpp
+++ b/SmartEVSE-3/src/glcd.cpp
@@ -745,6 +745,8 @@ const char * getMenuItemOption(uint8_t nav) {
             return Str;
         case MENU_3F:
             return enable3f ? "Yes" : "No";
+        case MENU_DEFAULT_ACCESS:
+            return defaultAccess ? "Def.Allow" : "Def.Deny";
         case MENU_CONFIG:
             if (Config) return StrFixed;
             else return StrSocket;
@@ -856,6 +858,7 @@ uint8_t getMenuItems (void) {
         MenuItems[m++] = MENU_IMPORT;                                           // - Import Current from Grid (A)
     }
     MenuItems[m++] = MENU_3F;
+    MenuItems[m++] = MENU_DEFAULT_ACCESS;
     MenuItems[m++] = MENU_MAX_TEMP;
     MenuItems[m++] = MENU_LOADBL;                                               // Load Balance Setting (0:Disable / 1:Master / 2-8:Node)
     if (Mode && LoadBl < 2) {                                                   // ? Mode Smart/Solar and Load Balancing Disabled/Master?
@@ -888,7 +891,9 @@ uint8_t getMenuItems (void) {
         }
         MenuItems[m++] = MENU_EVMETER;                                          // - Type of EV electric meter (0: Disabled / Constants EM_*)
         if (EVMeter) {                                                          // - ? EV meter configured?
-            MenuItems[m++] = MENU_EVMETERADDRESS;                               // - - Address of EV electric meter (5 - 254)
+            if (EVMeter != EM_API) {                                            // - If EV meter is not API, do not show address option
+                MenuItems[m++] = MENU_EVMETERADDRESS;                           // - - Address of EV electric meter (5 - 254)
+            }
         }
         if (LoadBl < 2) {                                                       // - ? Load Balancing Disabled/Master?
             if (MainsMeter == EM_CUSTOM || PVMeter == EM_CUSTOM || EVMeter == EM_CUSTOM) { // ? Custom electric meter used?

--- a/integrations/home-assistant/automation-mqtt.yaml
+++ b/integrations/home-assistant/automation-mqtt.yaml
@@ -1,0 +1,107 @@
+# Example automations to use with SmartEVSE in MQTT client mode with HomeAssistant
+
+automations:
+  # The following automation updates the SmartEVSE Access input_select helper
+  # with the value received from MQTT
+  - alias: Set SmartEVSE Access Selector from MQTT
+    description: ""
+    trigger:
+      - platform: mqtt
+        topic: SmartEVSE/Access
+    condition:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: input_select.smartevse_access
+            state: "{{ trigger.payload }}"
+    action:
+      - service: input_select.select_option
+        target:
+          entity_id: input_select.smartevse_access
+        data:
+          option: "{{ trigger.payload }}"
+    mode: single
+
+  # The following automation updates the SmartEVSE Mode input_select helper
+  # with the value received from MQTT
+  - alias: Set SmartEVSE Mode Selector from MQTT
+    description: ""
+    trigger:
+      - platform: mqtt
+        topic: SmartEVSE/Mode
+    condition:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: input_select.smartevse_mode
+            state: "{{ trigger.payload }}"
+    action:
+      - service: input_select.select_option
+        target:
+          entity_id: input_select.smartevse_mode
+        data:
+          option: "{{ trigger.payload }}"
+    mode: single
+
+  # The following automation pushes EV meter stats to the SmartEVSE
+  # The SmartEVSE will use this data to calculate the energy charged
+  # In this example the data is taken from an SDM630 modbus Kwh meter and sent every 3 seconds
+  # It stops sending if HomeAssistant hasn't received sensor values from the metering device for 60 seconds
+  - alias: Set SmartEVSE EVMeter values
+    description: ""
+    trigger:
+      - platform: time_pattern
+        minutes: "*"
+        seconds: /3
+        hours: "*"
+    condition:
+      - condition: template
+        value_template: >-
+          {{
+          (as_timestamp(now())-as_timestamp(states.sensor.sdm630_frequency_of_supply_voltages.last_updated))
+          < 60 }}
+    action:
+      - service: mqtt.publish
+        data:
+          topic: SmartEVSE/Set/EVMeter
+          payload_template: >-
+            {{ states('sensor.sdm630_phase_1_current') | int * 10 }}:{{
+            states('sensor.sdm630_phase_2_current') | int * 10 }}:{{
+            states('sensor.sdm630_phase_3_current') | int * 10 }}:{{
+            ((states('sensor.sdm630_total_system_power') | float) * 1000) | int
+            }}:{{ (states('sensor.sdm630_import_wh_since_last_reset') | float *
+            1000) | int }}
+    mode: single
+
+  # The following automation sets MainsMeter values so SmartEVSE can use it for balancing
+  # In this example I use my P1 meter values and calculate the current manually
+  # I do this because I also have a single phase PV inverter on phase 2 and the P1 meter data does not include export
+  # It stops sending if HomeAssistant hasn't received sensor values from the metering device for 60 seconds
+  - alias: Set SmartEVSE MainsMeter values
+    description: ""
+    trigger:
+      - platform: time_pattern
+        minutes: "*"
+        seconds: /5
+        hours: "*"
+    condition:
+      - condition: template
+        value_template: >-
+          {{
+          (as_timestamp(now())-as_timestamp(states.sensor.voltage_phase_1.last_updated))
+          < 60 }}
+    action:
+      - service: mqtt.publish
+        data:
+          topic: SmartEVSE/Set/MainsMeter
+          payload_template: >-
+            {% set pcp1 = states('sensor.power_consumed_phase_1') | float(0) * 1000
+            %} {% set vp1 = states('sensor.voltage_phase_1') | float(0) %} {% set
+            pcp2 = states('sensor.power_consumed_phase_2') | float(0) * 1000 %} {%
+            set ppp2 = states('sensor.power_produced_phase_2') | float(0) * 1000 %}
+            {% set vp2 = states('sensor.voltage_phase_2') | float(0) %} {% set pcp3
+            = states('sensor.power_consumed_phase_3') | float(0) * 1000 %} {% set
+            vp3 = states('sensor.voltage_phase_3') | float(0) %} {{ (pcp1 / vp1 *
+            10) | int }}:{% if ppp2 > 0 %}{{ -(ppp2 / vp2 * 10) | int }}{% else %}{{
+            (pcp2 / vp2 * 10) | int }}{% endif %}:{{ (pcp3 / vp3 * 10) | int }}
+    mode: single

--- a/integrations/home-assistant/configuration-mqtt.yaml
+++ b/integrations/home-assistant/configuration-mqtt.yaml
@@ -1,0 +1,86 @@
+# Example configuration to use SmartEVSE in MQTT client mode with HomeAssistant
+
+input_select:
+  smartevse_mode:
+    name: SmartEVSE Mode
+    options:
+      - Normal
+      - Smart
+      - Solar
+    initial: Normal
+  smartevse_access:
+    name: SmartEVSE Access
+    options:
+      - Deny
+      - Allow
+    initial: Deny
+
+sensor:
+  - platform: mqtt
+    state_topic: SmartEVSE/ModeName
+    unique_id: smartevse_mode
+    name: SmartEVSE Mode
+    icon: mdi:application-cog-outline
+
+  - platform: mqtt
+    state_topic: SmartEVSE/Access
+    unique_id: smartevse_access
+    name: SmartEVSE Access
+    icon: mdi:lock-outline
+
+  - platform: mqtt
+    state_topic: SmartEVSE/EVConnected
+    unique_id: smartevse_ev_connected
+    name: SmartEVSE EV Connected
+    icon: mdi:power-plug-outline
+
+  - platform: mqtt
+    state_topic: SmartEVSE/State
+    unique_id: smartevse_state
+    name: SmartEVSE State
+    icon: mdi:car-electric-outline
+
+  - platform: mqtt
+    state_topic: SmartEVSE/ChargeCurrent
+    value_template: "{{ value | int / 10 }}"
+    unique_id: smartevse_charge_current
+    device_class: current
+    unit_of_measurement: "A"
+    name: SmartEVSE Charge Current
+    icon: mdi:current-ac
+
+  - platform: mqtt
+    state_topic: SmartEVSE/OverrideCurrent
+    value_template: "{{ value | int / 10 }}"
+    unique_id: smartevse_override_current
+    device_class: current
+    unit_of_measurement: "A"
+    name: SmartEVSE Override Current
+    icon: mdi:current-ac
+
+  - platform: mqtt
+    state_topic: SmartEVSE/EVChargedKWH
+    value_template: "{{ value | float | round(2) }}"
+    unique_id: smartevse_ev_charged_kwh
+    device_class: power
+    unit_of_measurement: "kWh"
+    name: SmartEVSE EV Charged KWh
+    icon: mdi:lightning-bolt-outline
+
+  - platform: mqtt
+    state_topic: SmartEVSE/Error
+    unique_id: smartevse_error
+    name: SmartEVSE Error
+    icon: mdi:alert-circle-outline
+
+  - platform: mqtt
+    state_topic: SmartEVSE/RFID
+    unique_id: smartevse_rfid_status
+    name: SmartEVSE RFID Status
+    icon: mdi:credit-card-outline
+
+  - platform: mqtt
+    state_topic: SmartEVSE/ThreePhaseEnabled
+    unique_id: smartevse_three_phase_enabled
+    name: SmartEVSE Three Phase Enabled
+    icon: mdi:numeric

--- a/integrations/home-assistant/dashboard-mqtt.yaml
+++ b/integrations/home-assistant/dashboard-mqtt.yaml
@@ -1,0 +1,38 @@
+# Example of dashboard to use with SmartEVSE in MQTT client mode with HomeAssistant
+
+views:
+  visible:
+    - title: Car
+      path: car
+      badges: [ ]
+      cards:
+        - type: vertical-stack
+          cards:
+            - type: entity
+              entity: input_select.smartevse_mode
+            - type: entity
+              entity: input_select.smartevse_access
+            - type: entities
+              entities:
+                - entity: sensor.smartevse_ev_connected
+                - entity: sensor.smartevse_charge_current
+                - entity: sensor.smartevse_override_current
+                - entity: sensor.smartevse_access
+                - entity: sensor.smartevse_error
+                - entity: sensor.smartevse_three_phase_enabled
+        - type: vertical-stack
+          cards:
+            - type: entity
+              entity: sensor.smartevse_state
+            - hours_to_show: 24
+              graph: line
+              type: sensor
+              name: Total Charged
+              entity: sensor.smartevse_ev_charged_kwh
+              detail: 1
+            - hours_to_show: 24
+              graph: line
+              type: sensor
+              name: Charging Power
+              entity: sensor.sdm630_total_system_power
+              detail: 1


### PR DESCRIPTION
Hello there!

An electric car is almost delivered to my doorstep, so I thought I'd share some of my hacked additions* to your code.

Note that I am by no means a C++ developer, so please forgive my code standards. It 'works on my machine' and that is about all the guarantees you will get, but I guess it is good enough to share so others could possibly improve on it and I can learn. :-)

Here is a screenshot of the values published into MQTT and the available things to set from MQTT;

<img width="236" alt="Screenshot 2022-10-09 at 21 10 40" src="https://user-images.githubusercontent.com/30956886/194775243-76e4714a-6e90-4b7e-aea4-2cdb3682d4f0.png">

As you can see, you can also publish/set some of the values. The values accepted are the same values as published on the MQTT topics (Yes/No, Allow/Deny, Smart/Normal/Solar, etc). The MainsMeter and EVMeter Set topics are a bit special. For MainsMeter all phase currents (don't forget to multiply these by 10) should be sent in one message with a `:` as delimiter, like `phase1:phase2:phase3`. For EVMeter all phase currents, total live power consumed (in watts) and total energy consumed (in wh) should be sent in one message with a `:` as delimiter, like `phase1:phase2:phase3:power:wh`.

All of the MQTT topics are published on a ~5 second interval.

I also added a check for value timeout when using MainsMeter API (very much like the modbus logic does). It should trigger a NO COMM error if the value has not been updated for 10 seconds straight. This should prevent overload situations to occur when API suddenly stops receiving values.

I also enabled 3-phase contactor to enable in Smart mode as the load balancing logic should deal with this already.

Last but not least I've added a new setting in the menu that allows you to set the default access upon a fresh start of SmartEVSE. In my case, I do not have a physical switch attached to the EVSE but I control everything from Home Assistant. I only want charging to be allowed when Home Assistant thinks this should be the case. Another example; if SmartEVSE reboots, I do not want to allow charging as a default but rather deny it. I know I could have just pretended I had a switch, but I think this solution is more elegant with the new API ways of control.

Let me know your feedback/comments and I will see what I can do to improve further.

New Swagger schema that incorporates the changes and elaborates on the MQTT settings;
```
openapi: 3.0.3
info:
  title: Smart-EVSE V3A - Custom Firmware
  version: 1.0.0
servers:
  - url: 'http://localhost'
    description: 'Example Server'
paths:
  /settings:
    get:
      operationId: getSettings
      tags:
        - Operations
      responses:
        '200':
          description: Operation OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  mode: 
                    description: |-
                      <b>0_OFF <br />
                      <b>1_NORMAL <br />
                      <b>2_SOLAR <br />
                      <b>3_SMART
                    type: string
                    example: "2_SOLAR"
                  mode_id:
                    type: integer
                  access: 
                    type: integer
                    minimum: 0
                    maximum: 1
                  temp: 
                    type: integer
                  evse:
                    type: object
                    properties:
                      connected:
                        type: boolean
                      mode: 
                        type: integer
                      charge_timer:
                        type: integer
                      solar_stop_timer:
                        type: integer
                      state:
                        type: string
                      state_id:
                        type: integer
                      error:
                        type: string
                      error_id:
                        type: integer
                  settings:
                    type: object
                    properties:
                      charge_current: 
                        type: integer
                      current_min: 
                        type: integer
                      current_max: 
                        type: integer
                      current_main: 
                        type: integer
                      solar_max_import: 
                        type: integer
                      solar_start_current: 
                        type: integer
                      solar_stop_time: 
                        type: integer
                      3phases_enabled: 
                        type: boolean
                      mains_meter: 
                        type: string
                  mqtt: 
                    type: object
                    properties:
                      status:
                        type: string
                        enum: ["Not Configured", "Disconnected", "Connected"]
                  home_battery:
                    type: object
                    properties:
                      current: 
                        type: integer
                      last_update: 
                        type: integer
                        example: 1647798299
                  phase_currents:
                    type: object
                    properties:
                      TOTAL:
                        type: integer
                      L1: 
                        type: integer
                      L2: 
                        type: integer
                      L3: 
                        type: integer
                      original_data:
                        type: object
                        properties:
                          TOTAL:
                            type: integer
                          L1: 
                            type: integer
                          L2: 
                            type: integer
                          L3: 
                            type: integer
    post:
      operationId: updateSettings
      tags:
        - Operations
      parameters:
        - in: query
          name: backlight
          description: |-
           Turns backlight on (1) or off (0)
          required: false
          schema:
            type: integer
        - in: query
          name: mode
          description: |-
            Only following values are permitted: <br />
              <b>0</b>: OFF <br />
              <b>1</b>: NORMAL <br />
              <b>2</b>: SOLAR <br />
              <b>3</b>: SMART
          required: false
          schema:
            type: integer
        - in: query
          name: stop_timer
          description: |-
            Set the stop timer to be used when there isn't sufficient solar power. Value must be >=0 and <= 60. Using 0 will disable the stop timer.
          required: false
          allowEmptyValue: true
          schema:
            type: integer
        - in: query
          name: disable_override_current
          description: |-
            If this parameter is passed the override current will be reset (value doesn't matter)
          required: false
          allowEmptyValue: true
          schema:
            type: integer
        - in: query
          name: override_current
          description: |-
            Works only when using <b>NORMAL</b> mode <br />
            Desired current multiplied by 10 <br />
            <br />
            Examples: <br />
            If the desired current is <b>8.3A</b> the value to be send is <b>83</b> <br />
            If the desired current is <b>6A</b> the value to be send is <b>60</b>
          required: false
          schema:
            type: integer
        - in: query
          name: enable_3phases
          description: |-
            Enables 3 phase mode by controlling a 2nd contactor (C2 port) <br /> <br />
            Note 1: The 2nd contactor will only be turned <b>ON</b> when using the <b>NORMAL</b> mode and when state chages to 2 (Charging) <br />
            Note 2: This is just changing the config setting, the contactor will not be controlled immedialty but only when there is a state change. <br />
            <br />
            If car is charging and you want to change from 1F to 3F:  <br />
            - Change mode to OFF <br />
            - Enable 3 phases <br />
            - Change mode to NORMAL <br />
          schema:
            type: string
        - in: query
          name: mqtt_broker_ip
          description: |-
            Sets the MQTT broker IP address to use (only IPv4 for now)
            Use an empty value to unconfigure/disable MQTT client
          required: false
          example: 192.168.1.10
          schema:
            type: string
        - in: query
          name: mqtt_broker_port
          description: |-
            Sets the MQTT broker port to use
            Use an empty value to reset t the default of 1883
          required: false
          example: 1883
          schema:
            type: string
        - in: query
          name: mqtt_user
          description: |-
            Sets the MQTT broker username
            Use an empty value to not use authentication
          required: false
          schema:
            type: string
        - in: query
          name: mqtt_password
          description: |-
            Sets the MQTT broker password
            Use an empty value to not use authentication
          required: false
          schema:
            type: string
        - in: query
          name: mqtt_topic_prefix
          description: |-
            Sets the MQTT topic prefix to use for subscribing and publishing
            Use an empty value to reset to the default, which is the AP hostname
          required: false
          schema:
            type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Nullable'
      responses:
        '200':
          description: Operation OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  result: 
                    type: string
  /currents:
    post:
      operationId: updateCurrentsData
      tags:
        - Operations
      parameters:
        - in: query
          name: battery_current
          description: |-
            Actual home battery current multiplied by 10 <br />
            A <b>positive</b> number means the home battery is <b>charging</b> <br />
            A <b>negative</b> number means the home battery is<b> discharging</b> <br />
          required: false
          schema:
            type: integer
        - in: query
          name: L1
          description: |-
            Note: Only works when MainsMeter == API <br />
            L1, L2 and L3 must be send all together otherwise the data won't be registered.<br />
            Ampere must be multiplied by 10 <br />
          required: false
          schema:
            type: integer
        - in: query
          name: L2
          description: |-
            Note: Only works when MainsMeter == API <br />
            L1, L2 and L3 must be send all together otherwise the data won't be registered.<br />
            Ampere must be multiplied by 10 <br />
          required: false
          schema:
            type: integer
        - in: query
          name: L3
          description: |-
            Note: Only works when MainsMeter == API <br />
            L1, L2 and L3 must be send all together otherwise the data won't be registered.<br />
            Ampere must be multiplied by 10 <br />
          required: false
          schema:
            type: integer
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Nullable'
      responses:
        '200':
          description: Operation OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  result: 
                    type: string
  /evmeter:
    post:
      operationId: updateEvMeterData
      tags:
        - Operations
      parameters:
        - in: query
          name: L1
          description: |-
            Measured charge current on L1
            Note: Only works when EVMeter == API <br />
            L1, L2, L3, W and KWH must be send all together otherwise the data won't be registered.<br />
            Ampere must be multiplied by 10 <br />
          required: false
          schema:
            type: integer
        - in: query
          name: L2
          description: |-
            Measured charge current on L2
            Note: Only works when EVMeter == API <br />
            L1, L2, L3, W and KWH must be send all together otherwise the data won't be registered.<br />
            Ampere must be multiplied by 10 <br />
          required: false
          schema:
            type: integer
        - in: query
          name: L3
          description: |-
            Measured charge current on L3
            Note: Only works when EVMeter == API <br />
            L1, L2, L3, W and KWH must be send all together otherwise the data won't be registered.<br />
            Ampere must be multiplied by 10 <br />
          required: false
          schema:
            type: integer
        - in: query
          name: W
          description: |-
            Measured charge power, in Watts
            Note: Only works when EVMeter == API <br />
            L1, L2, L3, W and KWH must be send all together otherwise the data won't be registered.<br />
          required: false
          schema:
            type: integer
        - in: query
          name: WH
          description: |-
            Total WH meter value, should only increase
            Used to calculate the charged WHs for the current charge session
            Note: Only works when EVMeter == API <br />
            L1, L2, L3, W and WH must be send all together otherwise the data won't be registered.<br />
          required: false
          schema:
            type: integer
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Nullable'
      responses:
        '200':
          description: Operation OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  result: 
                    type: string
  /reboot:
    post:
      operationId: rebootEvse
      tags:
        - Operations
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Nullable'
      responses:
        '200':
          description: Operation OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  result: 
                    type: string
components:
  schemas:
    Nullable:
      type: object
      nullable: true
```
