### PR TITLE
Fix for EVMeter ABB B23/B24

### DIFF
--- a/SmartEVSE-3/platformio.ini
+++ b/SmartEVSE-3/platformio.ini
@@ -37,7 +37,7 @@ board_build.partitions = partitions_custom.csv
 [env:release]
 platform = espressif32
 platform_packages =
-   framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32#master
+   framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32#2.0.3
 extra_scripts = pre:eModbus-fix/fix.py
 build_flags = 
 	-DLOG_LEVEL=5

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -1807,8 +1807,13 @@ void requestEnergyMeasurement(uint8_t Meter, uint8_t Address, bool Export) {
             if (Export) ModbusReadInputRequest(Address, EMConfig[Meter].Function, EMConfig[Meter].ERegister_Exp, 2);
             else        ModbusReadInputRequest(Address, EMConfig[Meter].Function, EMConfig[Meter].ERegister, 2);
             break;
-        case EM_FINDER:
         case EM_ABB:
+            // Note:
+            // - ABB uses 64bit values for this register (size 2)
+            if (Export) requestMeasurement(Meter, Address, EMConfig[Meter].ERegister_Exp, 2);
+            else        requestMeasurement(Meter, Address, EMConfig[Meter].ERegister, 2);
+            break;
+        case EM_FINDER:
         case EM_EASTRON:
         case EM_WAGO:
             if (Export) requestMeasurement(Meter, Address, EMConfig[Meter].ERegister_Exp, 1);
@@ -2221,11 +2226,17 @@ void Timer1S(void * parameter) {
  */
 signed int receiveEnergyMeasurement(uint8_t *buf, uint8_t Meter) {
     switch (Meter) {
+        case EM_ABB:
+            // Note:
+            // - ABB uses 32-bit values, except for this measurement it uses 64bit unsigned int format
+            // We skip the first 4 bytes (effectivaly creating uint 32). Will work as long as the value does not exeed  roughly 20 million
+            return receiveMeasurement(buf, 1, EMConfig[Meter].Endianness, MB_DATATYPE_INT32, EMConfig[Meter].EDivisor-3);
         case EM_SOLAREDGE:
             // Note:
             // - SolarEdge uses 16-bit values, except for this measurement it uses 32bit int format
             // - EM_SOLAREDGE should not be used for EV Energy Measurements
-            return receiveMeasurement(buf, 0, EMConfig[Meter].Endianness, MB_DATATYPE_INT32, EMConfig[Meter].EDivisor - 3);
+
+            return receiveMeasurement(buf, 0, EMConfig[Meter].Endianness, MB_DATATYPE_INT32, EMConfig[Meter].EDivisor-3);
         default:
             return receiveMeasurement(buf, 0, EMConfig[Meter].Endianness, EMConfig[Meter].DataType, EMConfig[Meter].EDivisor - 3);
     }


### PR DESCRIPTION
Fixes Total kWh not working on ABB B23/B24 meters
Register 5000 is a 64bit value, other registers are 32bit Request the full register, but discard the first bytes. This works as long as the value stays less than 32bits