### PR TITLE
Fix number of phases on lcd display when charging 2 phases and contac…

### DIFF
--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -2214,7 +2214,7 @@ void Timer1S(void * parameter) {
                 }
 
                 if (EnableC2 != AUTO) {
-                    if (Nr_Of_Phases_Charging != 1 && (EnableC2 == ALWAYS_OFF || (EnableC2 == SOLAR_OFF && Mode == MODE_SOLAR))) {
+                    if (Nr_Of_Phases_Charging != 1 && (EnableC2 == ALWAYS_OFF || (EnableC2 == SOLAR_OFF && Mode == MODE_SOLAR)) && EnableC2 != NOT_PRESENT) {
                         _LOG_A("Error in detecting phases: EnableC2=%s and Nr_Of_Phases_Charging=%i.\n", StrEnableC2[EnableC2], Nr_Of_Phases_Charging);
                         Nr_Of_Phases_Charging = 1;
                         _LOG_A("Setting Nr_Of_Phases_Charging to 1.\n");


### PR DESCRIPTION
The LCD display shows SMART1F when charging 2 phases with no contactor C2 present. The function that forces the number of phases to 1 does not include the NOT_PRESENT status of C2.

Tested this fix on my SmartEVSE with success.