### PR TITLE
fix mainsmeter date/time alignment and control box right margin

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -158,11 +158,13 @@
             $('#phase_original_3').text((data.phase_currents.original_data.L3/10).toFixed(1) + " A");
 
             if(data.phase_currents.last_data_update > 0) {
-            $('#p1_data_time').text(new Date(data.phase_currents.last_data_update * 1000).toLocaleTimeString());
-            $('#p1_data_date').text(new Date(data.phase_currents.last_data_update * 1000).toLocaleDateString());
-              $('[id=with_p1_api_data]').show();
+              $('#p1_data_time').text(new Date(data.phase_currents.last_data_update * 1000).toLocaleTimeString());
+              $('#p1_data_date').text(new Date(data.phase_currents.last_data_update * 1000).toLocaleDateString());
+              $('[id=with_p1_api_data_date]').show();
+              $('[id=with_p1_api_data_time]').show();
             } else {
-              $('[id=with_p1_api_data]').hide();
+              $('[id=with_p1_api_data_date]').hide();
+              $('[id=with_p1_api_data_time]').hide();
             }
 
             if(data.home_battery.last_update == 0) {
@@ -420,24 +422,22 @@
                                           <div class="h5 mb-0 mr-3 text-gray-800" id="phase_3" style="text-align: right;"></div>
                                         </div>
                                     </div>
-                                    <div  id="with_p1_api_data">
-                                      <div class="row no-gutters align-items-center">
-                                        <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
-                                            Date:
-                                          </div>
-                                          <div class="col">
-                                            <div class="h5 mb-0 mr-3 text-gray-800" id="p1_data_date" style="text-align: right;"></div>
-                                          </div>
-                                      </div>
-                                      <div class="row no-gutters align-items-center">
-                                        <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
-                                            Time:
-                                          </div>
-                                          <div class="col">
-                                            <div class="h5 mb-0 mr-3 text-gray-800" id="p1_data_time" style="text-align: right;"></div>
-                                          </div>
-                                      </div>
-                                  </div>
+                                    <div class="row no-gutters align-items-center" id="with_p1_api_data_date">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                          Date:
+                                        </div>
+                                        <div class="col">
+                                          <div class="h5 mb-0 mr-3 text-gray-800" id="p1_data_date" style="text-align: right;"></div>
+                                        </div>
+                                    </div>
+                                    <div class="row no-gutters align-items-center" id="with_p1_api_data_time">
+                                      <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 100px;">
+                                          Time:
+                                        </div>
+                                        <div class="col">
+                                          <div class="h5 mb-0 mr-3 text-gray-800" id="p1_data_time" style="text-align: right;"></div>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="col-auto">
                                     <i class="fas fa-clipboard-list fa-2x text-gray-300">


### PR DESCRIPTION
Some minor layout fixes for the local web-ui:
Before
![image](https://user-images.githubusercontent.com/7497671/236784334-4fbb8acf-fbbd-4ca5-8c65-1d0d77fac181.png)
After
![image](https://user-images.githubusercontent.com/7497671/236784816-c24fe6cd-ce4b-4374-9007-bd9e4716f7cc.png)

Before
![image](https://user-images.githubusercontent.com/7497671/236784531-602a18de-598c-4503-871b-93cebe2b878d.png)
After
![image](https://user-images.githubusercontent.com/7497671/236784903-d7f294ba-0a53-4638-93ac-51174eb67dbd.png)
