### PR TITLE
PWM override feature on CP

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -64,6 +64,7 @@
 
 
             $('#mode').text(data.mode);
+            $('#dutycycle').text(data.pwm);
             $('#car_connected').text(data.car_connected ? "Yes" : "No");
             $('#state').text(data.evse.state);
             $('#temp').text(data.evse.temp + " °C / " + data.evse.temp_max + " °C");
@@ -234,6 +235,14 @@
                                             </div>
                                             <div class="col">
                                               <div class="h5 mb-0 mr-3 text-gray-800" id="mode"></div>
+                                            </div>
+                                        </div>
+                                        <div class="row no-gutters align-items-center">
+                                            <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
+                                                Duty cycle (/1024):
+                                            </div>
+                                            <div class="col">
+                                                <div class="h5 mb-0 mr-3 text-gray-800" id="dutycycle"></div>
                                             </div>
                                         </div>
                                         <div class="row no-gutters align-items-center">
@@ -683,7 +692,11 @@
                     function rawData() {
                       window.location.href = "/settings";
                     }
-                </script>
+                    function postPWM(value) {
+                       $.post("/pwm?value=" + value);
+                       event.preventDefault();
+                     }
+                    </script>
 
                 <!-- Earnings (Monthly) Card Example -->
                 <div style="margin-bottom: 20px;">
@@ -744,9 +757,19 @@
                                           <button onclick="update()" style="width: 100px; display:inline-block;">Update</button>
                                           <button onclick="rawData()" style="width: 120px; display:inline-block;">Raw Data</button>
                                         </div>
+                                        <div class="row no-gutters align-items-center">
+                                            <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
+                                                Override PWM:
+                                            </div>
+                                            <div class="col">
+                                                <button onclick="postPWM(0)" style="width: 120px; display:inline-block;">0&#37;</button>
+                                                <button onclick="postPWM(50)" style="width: 120px; display:inline-block;">5&#37;</button>
+                                                <button onclick="postPWM(250)" style="width: 120px; display:inline-block;">25&#37;</button>
+                                                <button onclick="postPWM(1024)" style="width: 120px; display:inline-block;">100&#37;</button>
+                                                <button onclick="postPWM(-1)" style="width: 120px; display:inline-block;">reset</button>
+                                            </div>
+                                        </div>
                                     </div>
-
-                                  </div>
                                 </div>
                             </div>
                         </div>

--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -519,6 +519,7 @@ void write_settings(void);
 void setSolarStopTimer(uint16_t Timer);
 void setState(uint8_t NewState);
 void setAccess(bool Access);
+void SetCPDuty(uint32_t DutyCycle);
 uint8_t setItemValue(uint8_t nav, uint16_t val);
 uint16_t getItemValue(uint8_t nav);
 void ConfigureModbusMode(uint8_t newmode);

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -92,6 +92,8 @@ uint16_t MaxCurrent = MAX_CURRENT;                                          // M
 uint16_t MinCurrent = MIN_CURRENT;                                          // Minimal current the EV is happy with (A)
 uint16_t ICal = ICAL;                                                       // CT calibration value
 uint8_t Mode = MODE;                                                        // EVSE mode (0:Normal / 1:Smart / 2:Solar)
+uint32_t CurrentPWM = 0;                                                        // EVSE mode (0:Normal / 1:Smart / 2:Solar)
+bool CPDutyOverride = false;
 uint8_t Lock = LOCK;                                                        // Cable lock (0:Disable / 1:Solenoid / 2:Motor)
 uint16_t MaxCircuit = MAX_CIRCUIT;                                          // Max current of the EVSE circuit (A)
 uint8_t Config = CONFIG;                                                    // Configuration (0:Socket / 1:Fixed Cable)
@@ -421,7 +423,14 @@ void SetCurrent(uint16_t current) {
     else if ((current > 510) && (current <= 800)) DutyCycle = (current / 2.5) + 640;
     else DutyCycle = 100;                                                   // invalid, use 6A
     DutyCycle = DutyCycle * 1024 / 1000;                                    // conversion to 1024 = 100%
+    SetCPDuty(DutyCycle);
+}
+
+// Write duty cycle to pin
+// Value in range 0 (0% duty) to 1024 (100% duty)
+void SetCPDuty(uint32_t DutyCycle){
     ledcWrite(CP_CHANNEL, DutyCycle);                                       // update PWM signal
+    CurrentPWM = DutyCycle;
 }
 
 
@@ -629,7 +638,7 @@ void setState(uint8_t NewState) {
         case STATE_A:                                                           // State A1
             CONTACTOR1_OFF;  
             CONTACTOR2_OFF;  
-            ledcWrite(CP_CHANNEL, 1024);                                        // PWM off,  channel 0, duty cycle 100%
+            SetCPDuty(1024);                                        // PWM off,  channel 0, duty cycle 100%
             timerAlarmWrite(timerA, PWM_100, true);                             // Alarm every 1ms, auto reload 
             if (NewState == STATE_A) {
                 ErrorFlags &= ~NO_SUN;
@@ -703,7 +712,7 @@ void setState(uint8_t NewState) {
             LCDTimer = 0;
             break;
         case STATE_C1:
-            ledcWrite(CP_CHANNEL, 1024);                                        // PWM off,  channel 0, duty cycle 100%
+            SetCPDuty(1024);                                        // PWM off,  channel 0, duty cycle 100%
             timerAlarmWrite(timerA, PWM_100, true);                             // Alarm every 1ms, auto reload 
                                                                                 // EV should detect and stop charging within 3 seconds
             C1Timer = 6;                                                        // Wait maximum 6 seconds, before forcing the contactor off.
@@ -1763,7 +1772,7 @@ void EVSEStates(void * parameter) {
                     setState(STATE_ACTSTART);
                     ActivationTimer = 3;
 
-                    ledcWrite(CP_CHANNEL, 0);                                   // PWM off,  channel 0, duty cycle 0%
+                    SetCPDuty(0);                                   // PWM off,  channel 0, duty cycle 0%
                                                                                 // Control pilot static -12V
                 }
             }
@@ -2023,7 +2032,7 @@ uint8_t PollEVNode = NR_EVSES;
                     } else {                                                    // Normal Mode
                         CalcBalancedCurrent(0);                                 // Calculate charge current for connected EVSE's
                         if (LoadBl == 1) BroadcastCurrent();                    // Send to all EVSE's (only in Master mode)
-                        if ((State == STATE_B) || (State == STATE_C)) SetCurrent(Balanced[0]); // set PWM output for Master
+                        if ((State == STATE_B) || (State == STATE_C) && !CPDutyOverride) SetCurrent(Balanced[0]); // set PWM output for Master
                     }
                     ModbusRequest = 0;
                     //_LOG_A("Task free ram: %u\n", uxTaskGetStackHighWaterMark( NULL ));
@@ -3056,6 +3065,7 @@ void StartwebServer(void) {
         DynamicJsonDocument doc(1200); // https://arduinojson.org/v6/assistant/
         doc["version"] = String(VERSION);
         doc["mode"] = mode;
+        doc["pwm"] = CurrentPWM;
         doc["mode_id"] = modeId;
         doc["car_connected"] = evConnected;
 
@@ -3414,6 +3424,28 @@ void StartwebServer(void) {
     },[](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final){
     });
 
+    webServer.on("/pwm", HTTP_POST, [](AsyncWebServerRequest *request) {
+        DynamicJsonDocument doc(200); 
+
+        if(request->hasParam("value")) {
+            String mode = request->getParam("value")->value();
+            int pwm = mode.toInt();
+            if (pwm < 0){
+                CPDutyOverride = false;
+                pwm = 150; // 15% until next loop, to be safe
+            }else{
+                CPDutyOverride = true;
+            }
+            SetCPDuty(pwm);
+            doc["value"] = pwm;
+
+            String json;
+            serializeJson(doc, json);
+            request->send(200, "application/json", json);
+
+        }
+    });
+
 #ifdef FAKE_RFID
     //this can be activated by: http://smartevse-xxx.lan/debug?showrfid=1
     webServer.on("/debug", HTTP_GET, [](AsyncWebServerRequest *request) {
@@ -3649,7 +3681,7 @@ void setup() {
     ledcAttachPin(PIN_LEDB, BLUE_CHANNEL);
     ledcAttachPin(PIN_LCD_LED, LCD_CHANNEL);
 
-    ledcWrite(CP_CHANNEL, 1024);                // channel 0, duty cycle 100%
+    SetCPDuty(1024);                // channel 0, duty cycle 100%
     ledcWrite(RED_CHANNEL, 255);
     ledcWrite(GREEN_CHANNEL, 0);
     ledcWrite(BLUE_CHANNEL, 255);


### PR DESCRIPTION
<img width="813" alt="afbeelding" src="https://github.com/serkri/SmartEVSE-3/assets/1292521/0d93849a-2a68-4985-9cc6-a77c1d3f18f4">

Shows current duty cycle of CP pin signal, and allows override via REST and Web UI.
Useful for setting to 5% for ISO 15118 development.

You can disable the override as well, resuming normal charge operations