### PR TITLE
Master/Slave WebUI modifications

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -64,8 +64,17 @@
 
 
             $('#mode').text(data.mode);
+            
             $('#dutycycle').text((data.evse.pwm*100/1024).toFixed(0) + " %");
-
+            
+            if(data.evse.loadbl > 1) {
+              $('[id=loadbl_node]').text("Slave Node "+(data.evse.loadbl-1));
+            } else if (data.evse.loadbl == 1) {
+              $('[id=loadbl_node]').text("Master");
+            } else {
+              $('[id=loadbl]').hide();
+            }
+            
             $('#car_connected').text(data.car_connected ? "Yes" : "No");
             $('#state').text(data.evse.state);
             $('#temp').text(data.evse.temp + " °C / " + data.evse.temp_max + " °C");
@@ -244,6 +253,14 @@
                                               <div class="h5 mb-0 mr-3 text-gray-800" id="mode"></div>
                                             </div>
                                         </div>
+                                        <div class="row no-gutters align-items-center" id="loadbl">
+                                            <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
+                                              Load Balance:
+                                            </div>
+                                            <div class="col">
+                                              <div class="h5 mb-0 mr-3 text-gray-800" id="loadbl_node"></div>
+                                            </div>
+                                        </div>                                        
                                         <div class="row no-gutters align-items-center" id="with_modem">
                                             <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                                 Duty cycle:

--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -68,11 +68,31 @@
             $('#dutycycle').text((data.evse.pwm*100/1024).toFixed(0) + " %");
             
             if(data.evse.loadbl > 1) {
+              $('[id=loadbl]').show();
+              $('[id=loadbl_text]').show();
               $('[id=loadbl_node]').text("Slave Node "+(data.evse.loadbl-1));
+              $('[id=loadbl_text_slave]').show();
+              $('[id=loadbl_text_master]').hide();
+              $('[id=form_mode] :input').prop('disabled',true);
+              $('[id=mode_override_current]').prop('disabled',true); 
+              $('[id=form_pwm] :input').prop('disabled',true);
             } else if (data.evse.loadbl == 1) {
+              $('[id=loadbl]').show();
+              $('[id=loadbl_text]').show(); 
               $('[id=loadbl_node]').text("Master");
+              $('[id=loadbl_text_slave]').hide();
+              $('[id=loadbl_text_master]').show();
+              $('[id=form_mode] :input').prop('disabled',false);
+              $('[id=mode_override_current]').prop('disabled',false); 
+              $('[id=form_pwm] :input').prop('disabled',false);
             } else {
               $('[id=loadbl]').hide();
+              $('[id=loadbl_text]').hide();
+              $('[id=loadbl_text_slave]').hide();
+              $('[id=loadbl_text_master]').hide();
+              $('[id=form_mode] :input').prop('disabled',false);
+              $('[id=mode_override_current]').prop('disabled',false); 
+              $('[id=form_pwm] :input').prop('disabled',false);
             }
             
             $('#car_connected').text(data.car_connected ? "Yes" : "No");
@@ -729,12 +749,21 @@
                             <div class="row no-gutters align-items-center">
                                 <div class="col mr-2">
                                     <div class="text font-weight-bold text-primary text-uppercase mb-1">Control</div>
+                                      <div class="row no-gutters align-items-center" id="loadbl_text">
+                                        <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
+                                         Load Balance:
+                                        </div>
+                                      <div class="col h5 mb-0 mr-3 font-weight-bold text-gray-800">
+                                          <span id="loadbl_text_slave">Slave node - control is disabled, perform changes on Master node.</span>
+                                          <span id="loadbl_text_master">Master node - control changes are propagated to Slave node(s).</span>
+                                      </div>                                      
+                                    </div>                                      
                                     <div class="row no-gutters align-items-center">
                                       <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                           Mode:
                                         </div>
                                         <div class="col">
-                                          <form class="form-inline">
+                                          <form class="form-inline" id="form_mode"> 
                                             <button id="mode_0" onclick="activate('0')" style="width: 100px; display:inline-block;">OFF</button>
                                             <button id="mode_1" onclick="activate('1')" style="width: 120px; display:inline-block;">NORMAL</button>
                                             <div id="with_mainsmeter" style="display: inline">
@@ -787,9 +816,11 @@
                                             Override PWM:
                                         </div>
                                         <div class="col">
+                                          <form class="form-inline" id="form_pwm">
                                             <button onclick="postPWM(0)" style="width: 120px; display:inline-block;">0&#37;</button>
                                             <button onclick="postPWM(50)" style="width: 120px; display:inline-block;">5&#37;</button>
                                             <button onclick="postPWM(-1)" style="width: 120px; display:inline-block;">reset</button>
+                                          </form>  
                                         </div>
                                     </div>
                                   </div>

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -3100,6 +3100,7 @@ void StartwebServer(void) {
         doc["evse"]["connected"] = evConnected;
         doc["evse"]["access"] = Access_bit == 1;
         doc["evse"]["mode"] = Mode;
+        doc["evse"]["loadbl"] = LoadBl;
         doc["evse"]["pwm"] = CurrentPWM;
         doc["evse"]["solar_stop_timer"] = SolarStopTimer;
         doc["evse"]["state"] = evstate;


### PR DESCRIPTION
This PR makes webui changes for master/slave(s) setups:
- displays EVSE Load balancing mode (Master / Slave Node X/ None)
- blocks control modifications on Slave Node(s) 
  note: modifications via API are still possible.
  
in a master/slave(s) setup charging mode / amperage / etc modifications should be done only on master which propagates changes to slave(s) via modbus: current web interface allows to perform changes also on slaves .. which results in non-working and/or inconsistent setup of the system (communication errors/slave not charging connected EV .. etc)  
  