### PR TITLE
Improved modem functionality

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -199,9 +199,9 @@
             }
 
             if(data.settings.modem == "Not present") {
-              $('[id=with_modem]').hide();
+              $('.with_modem').hide();
             } else {
-              $('[id=with_modem]').show();
+              $('.with_modem').show();
             }
 
             $('#evmeter_description').text(data.ev_meter.description);
@@ -249,7 +249,7 @@
                                               <div class="h5 mb-0 mr-3 text-gray-800" id="mode"></div>
                                             </div>
                                         </div>
-                                        <div class="row no-gutters align-items-center" id="with_modem">
+                                        <div class="row no-gutters align-items-center with_modem">
                                             <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                                 Duty cycle:
                                             </div>
@@ -362,7 +362,7 @@
                     <!-- END ROW -->
                     <div class="row">
 
-                    <div class="col-xl-3 col-md-6 mb-4" id="with_modem">
+                    <div class="col-xl-3 col-md-6 mb-4 with_modem">
                         <div class="card border-left-danger shadow h-100 py-2">
                             <div class="card-body">
                                 <div class="row no-gutters align-items-center">
@@ -805,7 +805,7 @@
                                           <button onclick="rawData()" style="width: 120px; display:inline-block;">Raw Data</button>
                                         </div>
                                     </div>
-                                    <div class="row no-gutters align-items-center" id="with_modem">
+                                    <div class="row no-gutters align-items-center with_modem">
                                         <div class="col-auto h5 mb-0 mr-3 font-weight-bold text-gray-800" style="width: 120px;">
                                             Override PWM:
                                         </div>


### PR DESCRIPTION
This PR features:
 - The ability to setup communication with car, according to ISO15118 standard
 - Work together with pyPLC (https://github.com/uhi22/pyPLC) which can handle the digital communication with the car, and submit the SoC states back to SmartEVSE
 - Compute the current SoC, based on the EV meter
 - Reliably reset SoC values upon disconnect with vehicle
 - "Re-plug" the vehicle if the communication fails, and after communication was succesfull to resume AC charging
 - Display the SoC values on the web UI

Work todo:
 - Set the battery capacity of the car via the menu, or via API. Currently hardcoded on 28kWh for Ioniq vehicle
 - Feature to stop charging once a specified SoC has been reached
 - Authorization of car based on MAC address of car

Please review and merge pr, rather than copy/pasting code. IMO git is not meant for copy-paste.
I'm happy to make changes or to add code/docs where needed.