### PR TITLE
Fix empty MQTT fields

### DIFF
--- a/SmartEVSE-3/data/index.html
+++ b/SmartEVSE-3/data/index.html
@@ -266,8 +266,8 @@
             }
 
             if (data.mqtt && !mqttEditMode) {
-                $('#mqtt_host').val(data.mqtt.broker_host);
-                $('#mqtt_port').val(data.mqtt.broker_port);
+                $('#mqtt_host').val(data.mqtt.host);
+                $('#mqtt_port').val(data.mqtt.port);
                 $('#mqtt_username').val(data.mqtt.username);
                 $('#mqtt_password').val(data.mqtt.password);
                 $('#mqtt_topic_prefix').val(data.mqtt.topic_prefix);


### PR DESCRIPTION
This should fix #166, as the keys the JS was looking for are called differently in the settings JSON.

~~Haven't tested it locally though.~~