### PR TITLE
fix: Potential workaround for modem operation w/normal access off

### DIFF
--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -2570,7 +2570,7 @@ void Timer1S(void * parameter) {
 #ifdef MODEM
         // Normally, the modem is enabled when Modem == Experiment. However, after a succesfull communication has been set up, EVSE will restart communication by replugging car and moving back to state B.
         // This time, communication is not initiated. When a car is disconnected, we want to enable the modem states again, but using 12V signal is not reliable (we just "replugged" via CP pin, remember).
-        // This counter just enables the state after 3 seconds of success. 
+        // This counter just enables the state after 3 seconds of success.
         if (DisconnectTimeCounter >= 0){
             DisconnectTimeCounter++;
         }

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -811,13 +811,8 @@ void setState(uint8_t NewState) {
 void setAccess(bool Access) {
     Access_bit = Access;
     if (Access == 0) {
-        if (Modem)
-            CP_OFF;
         if (State == STATE_C) setState(STATE_C1);                               // Determine where to switch to.
         else if (State == STATE_B || State == STATE_MODEM_REQUEST || State == STATE_MODEM_WAIT || State == STATE_MODEM_DONE || State == STATE_MODEM_DENIED) setState(STATE_B1);
-    } else{
-        if (Modem)
-            CP_ON;
     }
 
 #ifdef MQTT
@@ -2529,21 +2524,21 @@ void Timer1S(void * parameter) {
                 //  - State STATE_B will enable CP pin again, if disabled. 
                 // This stage we are now in is just before we enable CP_PIN and resume via STATE_B
 
+                // Reset CP to idle & turn off, it will be turned on again later for another try
+                SetCPDuty(1024);
+                CP_OFF;
+
                 // Check whether the EVCCID matches the one required
                 if (strcmp(RequiredEVCCID, "") == 0 || strcmp(RequiredEVCCID, EVCCID) == 0) {
                     // We satisfied the EVCCID requirements, skip modem stages next time
                     ModemStage = 1;
 
-                    setState(STATE_B);                                     // switch to STATE_ACTSTART
+                    setState(STATE_B);                                     // switch to STATE_B
                     GLCD();                                                // Re-init LCD (200ms delay)
                 } else {
                     // We actually do not want to continue charging and re-start at modem request after 60s
                     ModemStage = 0;
                     LeaveModemDeniedStateTimer = 60;
-
-                    // Reset CP & turn off
-                    SetCPDuty(1024);
-                    CP_OFF;
 
                     // Change to MODEM_DENIED state
                     setState(STATE_MODEM_DENIED);
@@ -2556,9 +2551,9 @@ void Timer1S(void * parameter) {
             if (LeaveModemDeniedStateTimer) LeaveModemDeniedStateTimer--;
             else{
                 LeaveModemDeniedStateTimer = -1;           // reset ModemStateDeniedTimer
+                setState(STATE_A);                         // switch to STATE_B
                 CP_ON;
-                setState(STATE_A);                         // switch to STATE_MODEM_REQUEST
-                GLCD();                                                // Re-init LCD (200ms delay)
+                GLCD();                                    // Re-init LCD (200ms delay)
             }
         }
 
@@ -2575,15 +2570,14 @@ void Timer1S(void * parameter) {
 #ifdef MODEM
         // Normally, the modem is enabled when Modem == Experiment. However, after a succesfull communication has been set up, EVSE will restart communication by replugging car and moving back to state B.
         // This time, communication is not initiated. When a car is disconnected, we want to enable the modem states again, but using 12V signal is not reliable (we just "replugged" via CP pin, remember).
-        // This counter just enables the state after 60 seconds of success. 
+        // This counter just enables the state after 3 seconds of success. 
         if (DisconnectTimeCounter >= 0){
             DisconnectTimeCounter++;
         }
 
-        // This state can be triggered manually in mode "OFF" or as physical unplug. 
-        if (DisconnectTimeCounter > 60){
+        if (DisconnectTimeCounter > 3){
             pilot = Pilot();
-            if (pilot == PILOT_12V && Access_bit != 0){
+            if (pilot == PILOT_12V){
                 DisconnectTimeCounter = -1;
                 DisconnectEvent();
             } else{ // Run again

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -3599,7 +3599,7 @@ void StartwebServer(void) {
 
         boolean evConnected = pilot != PILOT_12V;                    //when access bit = 1, p.ex. in OFF mode, the STATEs are no longer updated
 
-        DynamicJsonDocument doc(1500); // https://arduinojson.org/v6/assistant/
+        DynamicJsonDocument doc(1600); // https://arduinojson.org/v6/assistant/
         doc["version"] = String(VERSION);
         doc["mode"] = mode;
         doc["mode_id"] = modeId;


### PR DESCRIPTION
In my case, CP_OFF inside the `setAccess` method wasn't required to maintain state sanity with the PEV. The combination of states within the code of this pull seems to work well, also with the 'autocharge' feature that continually loops through multiple Modem Setup phases.

It also fires the disconnect event after the cable has being disconnected for 3 seconds instead of 60, so the session is cleared (and access is revoked again) fast. If you cycle through the modes after successful 'authentication' (and set the mode to OFF), it is also possible to resume the session without needing another Modem Request cycle as long as the cable remains connected to the vehicle. So that's pretty neat.

Anyway, YMMV with these changes. I will be using this fix for my daily driver the next few days.

Also had to increase the JSON doc size, as it was not enough for all of the data with Modem enabled resulting in weird javascript console errors of missing properties.