### PR TITLE
evse.cpp: remove announce of removed sensor

### DIFF
--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -2381,7 +2381,6 @@ void SetupMQTTClient() {
     optional_payload = jsna("device_class","current") + jsna("unit_of_measurement","A") + jsna("value_template", R"({{ value | int / 10 }})");
     announce("Charge Current", "sensor");
     announce("Max Current", "sensor");
-    announce("EV Charge Current", "sensor");
     if (MainsMeter) {
         announce("Mains Current L1", "sensor");
         announce("Mains Current L2", "sensor");


### PR DESCRIPTION
EV Charge Current MQTT topic was removed in #172, this PR removes the announcement of the sensor to HA.