### PR TITLE
Fixed modbus-bridge for other addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ The addresses on the tcp modbus are the same addresses as they are on the RTU mo
 E.g. my MainsMeter is at slave address 0x0a, so this command reads register 70decimal and following:<br />
 mbpoll -a10 -t 3:hex -r 70 -c 10 10.0.0.76
 
+Note: if you want to read from a modbus-address which is not used by SmartEVSE you need to register this address by:
+```
+curl -X POST http://smartevse-xxxxx.lan/modbus?bridge_meter_address=xxx
+```
+
+_Be aware this function unfortunately about to be removed in version [dingo35/SmartEVSE-3.5](https://github.com/dingo35/SmartEVSE-3.5)_ 
+
 # Simple Timer
 
 There is a simple timer implemented on the webserver, for Delayed Charging.

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -4275,7 +4275,7 @@ void StartwebServer(void) {
             int address = request->getParam("bridge_meter_address")->value().toInt();
             doc["bridge_meter_address"] = "Value not allowed";                  //will be overwritten when success bridging
             if ( address >= 10 && address <= 249) {
-                MBbridge.attachServer(MainsMeterAddress, MainsMeterAddress, ANY_FUNCTION_CODE, &MBclient);
+                MBbridge.attachServer(address, address, ANY_FUNCTION_CODE, &MBclient);
                 doc["bridge_meter_address"] = address;
             }
             String json;


### PR DESCRIPTION
When trying to use the modbus-bridge for a not by SmartEVSE used modbus-address, the newly used modbus address needs to be registered by the /modbus endpoint, unfortunately the code didn't use the passed address but the MainsMeterAddress. Also added a note to the readme.